### PR TITLE
Fix bug currently on staging

### DIFF
--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -51,7 +51,6 @@ module.exports = {
     // each participant's completedTasks counter
     volunteersCompleted: function() {
       var task = this;
-      if (task.state !== 'completed') return;
 
       Volunteer.find({ taskId: task.id }).exec(function(err, volunteers){
         if (err) return done(err);
@@ -137,7 +136,7 @@ module.exports = {
       model: model
     }, done);
   },
-  
+
   sendNotifications: function(i) {
     i = i || 0;
 


### PR DESCRIPTION
During the demo at the end of last week, we encountered a bug on staging. This bug prevented badges from being awarded for task completion, though not for publishing tasks.

The logic gate to check for the task state was always returning. This is because this function is called from the beforeUpdate lifecycle callback on the Task model. That means, that the changes (including the state change) have not yet been saved to the database. This results in every task returning early from this function and therefore no badges being assigned.

Instead, we’ll rely on the logic gate that is within the lifecycle callback (the switch/case statement) and assume that anytime this function is called the task has been appropriately marked as “completed”.