### PR TITLE
Release dev to staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dir": "."
   },
   "scripts": {
-    "preinstall": "if [ \"$THEME\" ]; then git clone $THEME _theme; npm run import --midas:dir=_theme; fi",
+    "preinstall": "if [ \"$THEME\" ]; then git clone $THEME _theme; npm run import --openopps-platform:dir=_theme; fi",
     "install": "npm run build",
     "test:api": "mocha test/test.upstart.js --recursive test/api",
     "test:browser": "npm run build && node test/browser/upstart.js",


### PR DESCRIPTION
Moving from version 0.8.0-rc-1 to version 0.8.0-rc-2.

The `npm import` script needs to properly refer to the package name.

