### PR TITLE
Update query for User model to include creator

### DIFF
--- a/api/controllers/ActivityController.js
+++ b/api/controllers/ActivityController.js
@@ -14,7 +14,16 @@ module.exports = {
         Volunteer.find({ taskId: taskIds }).exec(function(err, vols) {
           if (err) return res.negotiate(err);
 
-          User.find({ id: _.pluck(vols, 'userId') }).exec(function(err, users) {
+          // Ensure that the User model is being queried for both the original
+          // task creator and the users that are labeled as volunteers.
+          var allUserIds = [
+
+            { id: _.pluck( tasks, 'userId' ) },
+            { id: _.pluck( vols, 'userId' ) },
+
+          ];
+
+          User.find( allUserIds ).exec(function(err, users) {
             if (err) return res.negotiate(err);
 
             badges.forEach(function(badge){

--- a/assets/js/backbone/apps/home/templates/home_badges_feed_template.html
+++ b/assets/js/backbone/apps/home/templates/home_badges_feed_template.html
@@ -29,13 +29,11 @@
         <% if ( b.badges.length > 0 ) { %>
         <ul class="list-unstyled">
           <% b.badges.forEach( function( badge ) { %>
-            <% if ( ! badge.silent ) { %>
             <li>
               <% badge.type = badge.type.replace( ' ', '-' ); %>
               <a href="/profile/<%- badge.user.id %>"><%- badge.user.name %></a> earned the <%- badge.type %> badge. <%- badge.description %>
               <img class="activity-feed--badge" src="/images/badges/<%- badge.type %>.png" alt="The <%- badge.type %> badge is awarded when you <%- badge.description %>" title="The <%- badge.type %> badge is awarded when you <%- badge.description %>">
             </li>
-            <% } %>
           <% } ); %>
         </ul>
         <% } %>


### PR DESCRIPTION
The original query for Users only included volunteers. This updated query will include the original task creators as well and allow for badges to show up on the Dashboard.