### PR TITLE
fixed badge image

### DIFF
--- a/docs/badges.md
+++ b/docs/badges.md
@@ -8,7 +8,7 @@ Badges are awarded for specific tasks completed or created.  They appear on the 
 ###  Newcomer
 First task completed by user
 
-![rocket ship with number three on it](../assets/images/badges/maker.png)
+![rocket ship with number one on it](../assets/images/badges/newcomer.png)
 
 
 ### Maker


### PR DESCRIPTION
The image for the Newcomer badge was linked to the wrong asset, fixed.