### PR TITLE
Revert `UserController` enable and disable

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -257,22 +257,16 @@ module.exports = {
     });
   },
 
-  findUserById: function(res, err, userInfo) {
-      userInfo.userDisabled = typeof userInfo.userDisabled === 'undefined' ? false : userInfo.userDisabled;
-      userInfo.errMsg = typeof userInfo.errMsg === 'undefined' ? '' : userInfo.errMsg;
-      if (err) { return res.send(400, { message: 'An error occurred looking up this user.', error: err }); }
-      user.disabled = userInfo.userDisabled;
-      user.save(function (err) {
-        if (err) { return res.send(400, { message: userInfo.errMsg, error: err }); }
-        return res.send(user);
-      });
-  },
-
   // Enable a disabled user
   enable: function (req, res) {
     // policies will ensure only admins can run this function
     User.findOneById(req.route.params.id, function (err, user) {
-      return findUserById(res, err, { user: user, userDisabled: false, errMsg: 'An error occurred enabling this user.' });
+      if (err) { return res.send(400, { message: 'An error occurred looking up this user.', error: err }); }
+      user.disabled = false;
+      user.save(function (err) {
+        if (err) { return res.send(400, { message: 'An error occurred enabling this user.', error: err }); }
+        return res.send(user);
+      });
     });
   },
 
@@ -288,7 +282,12 @@ module.exports = {
         });
       } else {
         User.findOneById(req.route.params.id, function (err, user) {
-          return findUserById(res, err, { user: user, userDisabled: true, errMsg: 'An error occurred disabling this user.' });
+          if (err) { return res.send(400, { message: 'An error occurred looking up this user.', error: err }); }
+          user.disabled = true;
+          user.save(function (err) {
+            if (err) { return res.send(400, { message: 'An error occurred disabling this user.', error: err }); }
+            return res.send(user);
+          });
         });
       }
     }

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -120,7 +120,9 @@ module.exports = {
   },
 
   beforeValidate: function(values, done) {
-    values.username = values.username.toLowerCase();
+    if ( values && values.username ) {
+      values.username = values.username.toLowerCase();
+    }
     done();
   },
 

--- a/api/notifications/comment.create.owner/notification.js
+++ b/api/notifications/comment.create.owner/notification.js
@@ -10,34 +10,37 @@ module.exports = {
   * @param {function} callback called with err, data
   * data.globals defaults to sails.config
   */
-  data: function(model, done) {
+  data: function( model, done ) {
+
     var data = {
-          comment: model,
-          commenter: {},
-          model: {},
-          owner: {}
-        };
-    User.findOne({ id: model.userId }).exec(function(err, commenter) {
-      if (err) return done(err);
+      comment: model,
+      commenter: {},
+      model: {},
+      owner: {},
+    };
 
-      var Model = (model.projectId) ? Project : Task,
-          modelID = model.projectId || model.taskId;
+    User.findOne( { id: model.userId } ).exec( function ( err, commenter ) {
 
-      data.commenter = commenter;
+      if ( err ) { return done( err ); }
 
-      Model.findOne({ id: modelID }).exec(function(err, model) {
-        if (err) return done(err);
+      var Model = ( model.projectId ) ? Project : Task;
+      var modelId = model.projectId || model.taskId;
+
+      // TODO: Does this need two references to the `commenter` object?
+      // Explore how `data` is being used within the Notification template and refactor, maybe.
+      data.owner = data.commenter = commenter;
+
+      Model.findOne( { id: modelId } ).exec( function( err, model ) {
+
+        if ( err ) { return done( err ); }
+
         data.model = model;
 
-        User.findOne({ id: model.userId }).exec(function(err, owner) {
-          if (err) return done(err);
-          data.owner = owner;
+        done( null, data );
 
-          done(null, data);
-        });
+      } );
 
-      });
+    } );
 
-    });
-  }
+  },
 };

--- a/test/api/sails/admin.test.js
+++ b/test/api/sails/admin.test.js
@@ -1,6 +1,7 @@
-var assert = require('chai').assert;
-var conf = require('./helpers/config');
-var utils = require('./helpers/utils');
+var assert = require( 'chai' ).assert;
+var expect = require( 'chai' ).expect;
+var conf = require( './helpers/config' );
+var utils = require( './helpers/utils' );
 var request;
 
 describe('admin:', function () {
@@ -15,27 +16,33 @@ describe('admin:', function () {
     });
 
     it('set admin', function (done) {
-      request.get({ url: conf.url + '/admin/admin/1?action=true'
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 403);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/admin/admin/1?action=true' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 403);
+          done(err);
+        }
+      );
     });
 
     it('remove admin', function (done) {
-      request.get({ url: conf.url + '/admin/admin/1?action=false'
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 403);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/admin/admin/1?action=false' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 403);
+          done(err);
+        }
+      );
     });
 
     it('get users', function (done) {
-      request.get({ url: conf.url + '/admin/users'
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 403);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/admin/users' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 403);
+          done(err);
+        }
+      );
     });
   });
 
@@ -49,53 +56,63 @@ describe('admin:', function () {
     });
 
     it('set admin', function (done) {
-      request.get({ url: conf.url + '/admin/admin/2?action=true'
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 200);
-        var b = JSON.parse(body);
-        assert.equal(b.id, 2);
-        assert.isTrue(b.isAdmin);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/admin/admin/2?action=true' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          assert.equal(b.id, 2);
+          assert.isTrue(b.isAdmin);
+          done(err);
+        }
+      );
     });
 
     it('remove admin', function (done) {
-      request.get({ url: conf.url + '/admin/admin/2?action=false'
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 200);
-        var b = JSON.parse(body);
-        assert.equal(b.id, 2);
-        assert.equal(b.isAdmin, false);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/admin/admin/2?action=false' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          assert.equal(b.id, 2);
+          assert.equal(b.isAdmin, false);
+          done(err);
+        }
+      );
     });
 
     it('get users', function (done) {
-      request.get({ url: conf.url + '/admin/users'
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 200);
-        var b = JSON.parse(body);
-        assert.isDefined(b.page);
-        assert.isDefined(b.count);
-        assert.isDefined(b.limit);
-        assert.isTrue(b.count > 0);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/admin/users' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          assert.isDefined(b.page);
+          assert.isDefined(b.count);
+          assert.isDefined(b.limit);
+          assert.isTrue(b.count > 0);
+          done(err);
+        }
+      );
     });
 
     it('search users', function (done) {
-      request.post({ url: conf.url + '/admin/users',
-                     form: { q: conf.defaultUser.username }
-                   }, function (err, response, body) {
-        assert.equal(response.statusCode, 200);
-        var b = JSON.parse(body);
-        assert.isDefined(b.page);
-        assert.isDefined(b.count);
-        assert.isDefined(b.limit);
-        assert.isTrue(b.count > 0);
-        assert.equal(b.users[0].username, conf.defaultUser.username);
-        done(err);
-      });
+      request.post(
+        {
+          url: conf.url + '/admin/users',
+          form: { q: conf.defaultUser.username },
+        },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          assert.isDefined(b.page);
+          assert.isDefined(b.count);
+          assert.isDefined(b.limit);
+          assert.isTrue(b.count > 0);
+          assert.equal(b.users[0].username, conf.defaultUser.username);
+          done(err);
+        }
+      );
     });
 
     it('reset user password', function (done) {
@@ -131,8 +148,8 @@ describe('admin:', function () {
         if (err) { return done(err); }
         var obj = conf.testPasswordResetUser.obj;
         var emailBefore = obj.username,
-            userBefore = obj.id,
-            emailAfter = emailBefore.replace('+test@', '@');
+          userBefore = obj.id,
+          emailAfter = emailBefore.replace('+test@', '@');
         // log back in as an administrator
         utils.login(request, conf.adminUser, function (err) {
           if (err) { return done(err); }
@@ -140,7 +157,7 @@ describe('admin:', function () {
           var adminEmail = obj.username;
           request.put({
             url: conf.url + '/user/' + userBefore,
-            form: { username: emailAfter }
+            form: { username: emailAfter },
           }, function(err, response, body) {
             if (err) { return done(err); }
             // Logged in users should get a 200 with the user object
@@ -155,17 +172,18 @@ describe('admin:', function () {
     });
 
     it('export', function (done) {
-      request.get({
-        url: conf.url + '/user/export'
-      }, function (err, response, body) {
-        assert.equal(response.statusCode, 200);
-        var testBody = '"user_id","name","username","title","agency","location","bio","admin","disabled"\n' +
-            '1,"' + conf.adminUser.name +  '","' + conf.adminUser.username + '","","","","",true,false\n' +
-            '2,"' + conf.defaultUser.name +  '","' + conf.defaultUser.username + '","","","","",false,false\n' +
-            '3,"' + conf.testPasswordResetUser.name +  '","' + conf.testPasswordResetUser.username + '","","","","",false,false\n';
-        assert.equal(body, testBody);
-        done(err);
-      });
+      request.get(
+        { url: conf.url + '/user/export' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var testBody = '"user_id","name","username","title","agency","location","bio","admin","disabled"\n' +
+              '1,"' + conf.adminUser.name +  '","' + conf.adminUser.username + '","","","","",true,false\n' +
+              '2,"' + conf.defaultUser.name +  '","' + conf.defaultUser.username + '","","","","",false,false\n' +
+              '3,"' + conf.testPasswordResetUser.name +  '","' + conf.testPasswordResetUser.username + '","","","","",false,false\n';
+          assert.equal(body, testBody);
+          done(err);
+        }
+      );
     });
   });
 });

--- a/test/api/sails/admin.test.js
+++ b/test/api/sails/admin.test.js
@@ -185,5 +185,43 @@ describe('admin:', function () {
         }
       );
     });
+
+
+    // Check disabling a user functionality
+    //
+    it( 'disables user', function ( done ) {
+
+      var userId = 2;
+
+      request.get(
+        { url: conf.url + '/user/disable/' + userId },
+        function ( error, response, body ) {
+          var user = JSON.parse( body );
+          expect( response.statusCode ).to.equal( 200 );
+          expect( user.disabled ).to.equal( true );
+          done();
+        }
+      );
+
+    } );
+
+    // Check enabling a user functionality
+    //
+    it( 'enables user', function ( done ) {
+
+      var userId = 2;
+
+      request.get(
+        { url: conf.url + '/user/enable/' + userId },
+        function ( error, response, body ) {
+          var user = JSON.parse( body );
+          expect( response.statusCode ).to.equal( 200 );
+          expect( user.disabled ).to.equal( false );
+          done();
+        }
+      );
+
+    } );
+
   });
 });

--- a/test/api/sails/user.test.js
+++ b/test/api/sails/user.test.js
@@ -463,7 +463,6 @@ describe('user:', function() {
     });
   });
 
-
   it('lockout user', function (done) {
     var count = 0;
     async.whilst(
@@ -499,4 +498,5 @@ describe('user:', function() {
     );
 
   });
+
 });


### PR DESCRIPTION
Because the `user` object needs to be looked up and modified before being saved, leaving the code as it was before makes the most sense without refactoring this out to a `UserUtil` service.

This PR should touch multiple issues, because of how related they are to the `User` model.

- [x] **#1175** *disabling users seems to be broken*
- [x] **#1171** *error turning a model into an object...*
- [ ] ~~**#1172** *travis should run `npm run demo`*~~

I'll have to verify the changes made here run successfully with `npm run demo`. The previous errors I was experiencing were related to these two methods `enable` and `disable`.