### PR TITLE
Refactor: extracts duplication from LikesController

### DIFF
--- a/api/controllers/LikeController.js
+++ b/api/controllers/LikeController.js
@@ -5,26 +5,7 @@
  * @description	:: Contains logic for handling requests.
  */
 
-var like = function (l, cb) {
-  Like.findOne({ where: l }, function (err, existing) {
-    if (err) { return cb(err, null); }
-    if (existing) { return cb(null, existing); }
-    Like.create(l, function (err, newLike) {
-      if (err) { return cb(err, null); }
-      return cb(null, newLike);
-    });
-  });
-};
-
-var unlike = function (l, cb) {
-  Like.findOne({ where: l}, function (err, newLike) {
-    if (err) { return cb(err); }
-    if (!newLike) { return cb(null); }
-    newLike.destroy(function(err) {
-      return cb(err);
-    });
-  });
-};
+var LikeActions = require(__dirname + "/../services/utils/likeActions");
 
 module.exports = {
 
@@ -109,11 +90,7 @@ module.exports = {
    * Syntax: /like/like/:projectId where :id is the projectId
    */
   like: function (req, res) {
-    var l = { projectId: req.params.id, userId: req.user[0].id };
-    like(l, function (err, like) {
-      if (err) { return res.send(400, { message: 'Error creating like.' }); }
-      return res.send(like);
-    });
+    new LikeActions(req, res, 'projectId').like();
   },
 
   /**
@@ -121,11 +98,7 @@ module.exports = {
    * Syntax: /like/likeu/:userId where :id is the userId
    */
   liket: function (req, res) {
-    var l = { taskId: req.params.id, userId: req.user[0].id };
-    like(l, function (err, like) {
-      if (err) { return res.send(400, { message: 'Error creating like.' }); }
-      return res.send(like);
-    });
+    new LikeActions(req, res, 'taskId').like();
   },
 
   /**
@@ -133,11 +106,7 @@ module.exports = {
    * Syntax: /like/likeu/:userId where :id is the userId
    */
   likeu: function (req, res) {
-    var l = { targetId: req.params.id, userId: req.user[0].id };
-    like(l, function (err, like) {
-      if (err) { return res.send(400, { message: 'Error creating like.' }); }
-      return res.send(like);
-    });
+    new LikeActions(req, res, 'targetId').like();
   },
 
   /**
@@ -145,11 +114,7 @@ module.exports = {
    * Syntax: Call /like/unlike/:projectId where :id is the projectId
    */
   unlike: function (req, res) {
-    var l = { projectId: req.params.id, userId: req.user[0].id };
-    unlike(l, function (err) {
-      if (err) { return res.send(400, { message: 'Error destroying like.' }); }
-      return res.send(null);
-    });
+    new LikeActions(req, res, 'projectId').unlike();
   },
 
   /**
@@ -157,11 +122,7 @@ module.exports = {
    * Syntax: Call /like/unlikeu/:userId where :id is the userId
    */
   unliket: function (req, res) {
-    var l = { taskId: req.params.id, userId: req.user[0].id };
-    unlike(l, function (err) {
-      if (err) { return res.send(400, { message: 'Error destroying like.' }); }
-      return res.send(null);
-    });
+    new LikeActions(req, res, 'taskId').unlike();
   },
 
   /**
@@ -169,10 +130,6 @@ module.exports = {
    * Syntax: Call /like/unlikeu/:userId where :id is the userId
    */
   unlikeu: function (req, res) {
-    var l = { targetId: req.params.id, userId: req.user[0].id };
-    unlike(l, function (err) {
-      if (err) { return res.send(400, { message: 'Error destroying like.' }); }
-      return res.send(null);
-    });
+    new LikeActions(req, res, 'targetId').unlike();
   }
 };

--- a/api/services/utils/likeActions.js
+++ b/api/services/utils/likeActions.js
@@ -1,0 +1,83 @@
+var _ = require('underscore');
+
+function LikeActions(req, res, type) {
+  this.req = req;
+  this.res = res;
+  this.type = type;
+}
+
+_.extend(LikeActions.prototype, {
+  like: function() {
+    var liker = new Liker(this.res, this.queryOptions());
+    this.findOne(liker.handler());
+  },
+
+  unlike: function() {
+    var unliker = new Unliker(this.res);
+    this.findOne(unliker.handler());
+  },
+
+  queryOptions: function(type) {
+    var options = { userId: this.req.user[0].id};
+    options[this.type] = this.req.params.id;
+    return options;
+  },
+
+  findOne: function(callback) {
+    Like.findOne({where: this.queryOptions()}).exec(function(err, record) {
+      if (err) { return callback(err); }
+      callback(record);
+    });
+  }
+});
+
+function Liker(res, options) {
+  this.res = res;
+  this.options = options;
+}
+
+_.extend(Liker.prototype, {
+  handler: function() {
+    return this.afterFind.bind(this);
+  },
+
+  afterFind: function(record) {
+    if (record) { return this.respond(null, record); }
+    Like.create(this.options, this.handleCreated.bind(this));
+  },
+
+  handleCreated: function(err, record) {
+    if (err) { return this.respond(err, null); }
+    return this.respond(null, record);
+  },
+
+  respond: function(err, record) {
+    if (err) { return this.res.send(400, { message: 'Error creating like.' }); }
+    return this.res.send(record);
+  }
+});
+
+function Unliker(res) {
+  this.res = res;
+}
+
+_.extend(Unliker.prototype, {
+  handler: function() {
+    return this.afterFind.bind(this);
+  },
+
+  afterFind: function(record) {
+    if (!record) { return this.respond(null); }
+
+    record.destroy(this.respond.bind(this));
+  },
+
+  respond: function(err) {
+    if (err) { return this.res.send(400, { message: 'Error destroying like.' }); }
+    return this.res.send(null);
+  }
+});
+
+
+module.exports = LikeActions;
+


### PR DESCRIPTION
        After the last batch of refactors the LikesController showed up
        as having the most technical debt. This seemed mostly related to
        duplicate methods.

        There is still some duplication in the controller actions that I
        haven't worked with, but the like and unlike related actions
        have be cleaned up:

        * Extracts a LikeActions module with three 'classes'
                * top level handler that takes dependencies and has two
                  methods: 'like', 'unlike'
                * classes for liking and unliking