### PR TITLE
Removes console logging in a test

### DIFF
--- a/test/api/sails/attachment.test.js
+++ b/test/api/sails/attachment.test.js
@@ -15,7 +15,6 @@ describe('attachments:', function () {
   before(function ( done ) {
     request = utils.init();
     Task.create( { userId: 2, state: 'draft' } ).exec( function ( err, t ) {
-      console.log( 'taskCreate exec callback', err );
       if ( err ) { return done( err ); }
       task = t;
       utils.logout(request, done);


### PR DESCRIPTION
        I thought I had left this behind with my task metrics work,
        but it turns out it was in another area of the code. I wanted to
        see cleaner tests anyways, so ...