### PR TITLE
[ hotfix ] Save as Draft

### DIFF
--- a/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
+++ b/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
@@ -212,7 +212,7 @@
       Save as Draft
     </button>
     <% } else { %>
-    <button type="submit" id="js-task-create" class="btn btn-c2 wizard-submit" data-state="save">
+    <button type="submit" class="btn btn-c2 wizard-submit" data-state="save">
       Save Changes
     </button>
     <% } %>

--- a/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
+++ b/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
@@ -1,12 +1,16 @@
 <form action="" id="task-edit-form">
 <div class="col-md-12 box center task-edit-button-bar">
   <div class="create__buttons">
+    <% if ( 'draft' === data.state ) { %>
     <button type="submit" id="js-task-create" class="btn btn-c2 wizard-submit" data-state="submit">
       Submit for Review
     </button>
-    <% if ( 'draft' === data.state ) { %>
     <button type="button" class="js-task-draft btn btn-border wizard-submit" data-state="draft">
       Save as Draft
+    </button>
+    <% } else { %>
+    <button type="submit" id="js-task-create" class="btn btn-c2 wizard-submit" data-state="save">
+      Save Changes
     </button>
     <% } %>
     <button class="btn btn-c0" id="task-view">Discard Changes</button>
@@ -200,12 +204,16 @@
 </div>
 <div class="col-md-12 box center task-edit-button-bar">
   <div class="create__buttons">
+    <% if ( 'draft' === data.state ) { %>
     <button type="submit" class="btn btn-c2 wizard-submit" data-state="submit">
       Submit for Review
     </button>
-    <% if ( 'draft' === data.state ) { %>
     <button type="button" class="js-task-draft btn btn-border wizard-submit" data-state="draft">
       Save as Draft
+    </button>
+    <% } else { %>
+    <button type="submit" id="js-task-create" class="btn btn-c2 wizard-submit" data-state="save">
+      Save Changes
     </button>
     <% } %>
     <button class="btn btn-c0" id="task-view">Discard Changes</button>

--- a/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
+++ b/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
@@ -36,13 +36,13 @@ var TaskEditFormView = Backbone.View.extend({
     //
     this.listenTo( this.options.model, 'task:update:success', function ( data ) {
 
-      if ( 'draft' !== data.attributes.state ) {
+      if ( 'draft' === data.attributes.state ) {
 
-        Backbone.history.navigate( 'tasks/' + data.attributes.id, { trigger: true } );
+        view.renderSaveSuccessModal();
 
       } else {
 
-        view.renderSaveSuccessModal();
+        Backbone.history.navigate( 'tasks/' + data.attributes.id, { trigger: true } );
 
       }
 
@@ -263,9 +263,13 @@ var TaskEditFormView = Backbone.View.extend({
       };
 
 
-      // Check if draft is being saved or if this is a submission.
+      // README: Check if draft is being saved or if this is a submission.
+      // If the state isn't a draft and it isn't simply being saved, then it will
+      // be submitted for review. `event.saveState` is true if the task is not a
+      // `draft` and assumes that the task is simply being updated rather than
+      // there being a need to "Submit for Review".
       //
-      if ( ! event.draft ) {
+      if ( ! event.draft && ! event.saveState ) {
         modelData.state = 'submitted';
       }
 
@@ -321,9 +325,14 @@ var TaskEditFormView = Backbone.View.extend({
 
     if ( e.preventDefault ) { e.preventDefault(); }
 
-    var tags    = [];
-    var oldTags = [];
-    var diff    = [];
+    var tags      = [];
+    var oldTags   = [];
+    var diff      = [];
+    var saveState = false;
+
+    if ( 'save' === this.$( '#js-task-create' ).data( 'state' ) ) {
+      saveState = true;
+    }
 
     // check all of the field validation before submitting
     var children = this.$el.find( '.validate' );
@@ -338,7 +347,7 @@ var TaskEditFormView = Backbone.View.extend({
       return;
     }
 
-    return this.trigger( 'task:tags:save:done', { draft: false } );
+    return this.trigger( 'task:tags:save:done', { draft: false, save: saveState } );
 
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openopps-platform",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Innovation platform providing collaboration and crowdsourcing tools",
   "dependencies": {
     "async": "^0.2.9",


### PR DESCRIPTION
The updating of previously created tasks when not in a "**Draft**" state reverted them into a "**Submitted**" state since the edit screen only had the options of "Submit for Review" or "Save as Draft". This branch updates this behavior to reflect what is in issue #1143.