### PR TITLE
Full-time details don’t have ‘task-time-estimate’

### DIFF
--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -46,18 +46,21 @@
           </div>
           <h2>Time Committment</h2>
           <div>
-            <% if (madlibTags['task-time-required']) { %>
+            <% if (madlibTags['task-time-required']) { %>   <!-- One-time, On-going, Full-Time Detail -->
               <%= madlibTags['task-time-required'][0].name %>
-            <% } else { %>
-              None
             <% } %>
-            &mdash;
-            <% if (madlibTags['task-time-estimate']) { %>
+            <% if (madlibTags['task-time-estimate']) { %>  <!-- 2-4 hours, etc. -->
+              &mdash;
                <%= madlibTags['task-time-estimate'][0].name %> per week
-            <% } else { %>
-              None
             <% } %>
           </div>
+          <% if (model.completedBy) { %>  <!-- estimated completion date -->
+          <h2>Target Date</h2>
+          <div>
+               <%= moment(model.completedBy).format('ddd, MMM D, YYYY') %>
+          </div>
+          <% } %>
+
           <h2>Work Location</h2>
           <div>
             <% if (madlibTags.location) { %>


### PR DESCRIPTION
also we don’t expect to ever not have ‘task-time-required’
so let’s never display “None”
Only display mdash when there’s a time estimate
Also, display “completedBy” if we have one!

addresses #1090