### PR TITLE
pin versions so that tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "devDependencies": {
     "casper-chai": "^0.2.1",
-    "mocha-casperjs": "^0.5.3",
+    "casperjs": "1.1.0-beta3",
+    "mocha-casperjs": "0.5.3",
     "nodemon": "^1.3.7",
     "pg": "~3.6.0",
     "phantomjs": "^1.9.16"


### PR DESCRIPTION
seems like newer version of casperjs,
either bet4 or beta5 has some incompatibility

ideally we'd fix the root cause for #1247 but hopefully this will get Travis to be green 