### PR TITLE
Use db-migrate to Manage Database Migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,15 @@ sudo: true
 language: node_js
 node_js:
   - "0.10"
+services:
+  - postgresql
+addons:
+  postgresql: "9.4"
 before_install:
+  - psql -c "CREATE DATABASE midas;" -U postgres
+  - psql -c "CREATE USER midas WITH PASSWORD 'midas';" -U postgres
+  - psql -c "GRANT ALL PRIVILEGES ON DATABASE midas to midas;" -U postgres
+  - psql -c "ALTER SCHEMA public OWNER TO midas;" -U postgres
   - "npm install npm@2.1.x -g"
 before_deploy: npm install -g https://github.com/18F/cf-blue-green/tarball/master
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,23 +115,53 @@ references", such as which issues were fixed.
 
 ### Database changes
 
-The database schema is managed in this repository under `/tools/postgres/`. When
-you first set up Midas and run `npm run init` the `init.sh` script sets up the database
-with the latest schema. Each subsequent run of `init.sh` checks the database version
-and runs migration scripts to update it if the database is out of data.
+The database schema is managed in this repository under `/migrations/`. When
+you first set up Midas and run `npm run init`, all migrations will be run, the
+first of which creates the initial schema.  Each subsequent run of `npm run
+migrate` checks the database version and runs migration scripts to update it if
+the database is out of date.  `npm run check-migrate` can be used to check for
+any pending migrations without applying them.
 
-When making a database change, write a shell script that updates the database to
-your desired schema. Save this shell script as `[version].sh` where `[version]`
-is the new version of the schema. Migration scripts should be saved in
-`/tools/postgres/migrate`. See scripts in that directory like `2.sh` for examples.
+When running `npm run start` or `npm run watch`, `npm run check-migrate` will
+be run automatically, alerting you to any pending migrations.
 
-Then, export the updated schema:
+Grunt tasks, `grunt db:migrate:up` and `grunt db:migrate:down`, can also be
+used to run specific migration scripts or to downgrade.  See the
+[sails-db-migrate
+documentation](https://github.com/building5/sails-db-migrate#running-migrations)
+or the [db-migrate
+documentation](http://umigrate.readthedocs.org/projects/db-migrate/en/v0.10.x/Getting%20Started/the%20commands/)
+for more details.
 
-```sh
-pg_dump -h localhost -p 5432 -U midas -s midas > ./tools/postgres/schema/current.sql
+Also note that running `npm run init`, `npm run install`, or `npm run demo`
+will automatically run `npm run migrate`, applying any pending migrations
+before continuing.
+
+#### Creating New Migrations
+
+Database migrations are written in javascript as
+[db-migrate](http://umigrate.readthedocs.org/projects/db-migrate/) scripts.
+
+New migrations are created using the `db:migrate:create` grunt task.
+
+```
+$ grunt db:migrate:create --name add-new-feature
++ db-migrate create add-new-feature
+DATABASE_URL=postgres://midas:****@localhost/midas
+[INFO] Created migration at /home/user/git/openopps-platform/migrations/20160316214102-add-new-feature.js
+
+Done, without errors.
 ```
 
-The schema is also updated each time you run `make build`.
+Edit the new file created by `grunt db:migrate:create` to add the new migration
+steps needed.  The `up` and `down` functions exported from the new migration
+file will be used to perform the migration.  See the [db-migrate
+documentation](http://umigrate.readthedocs.org/projects/db-migrate/en/latest/Getting%20Started/usage/#creating-migrations)
+for the function signatures, examples, and tips.
+
+Many common SQL statements for manipulating the database schema and data are
+supported by the db-migrate's
+[javascript API](http://umigrate.readthedocs.org/projects/db-migrate/en/latest/API/SQL/).
 
 ## <a name="submit"></a> Submission Guidelines
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
   grunt.loadTasks(depsPath + '/grunt-contrib-concat/tasks');
   grunt.loadTasks(depsPath + '/grunt-contrib-watch/tasks');
   grunt.loadTasks( 'node_modules/grunt-sass/tasks' );
+  require('sails-db-migrate').gruntTasks(grunt);
 
   // -------------------------------------------------------------------
   // Tooling Configuration

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -279,7 +279,6 @@ It is not necessary to edit any config files to run the demo locally.  You may o
 
 From the root of the openopps directory, initialize the database:
 
-     npm run migrate
      npm run init
 
 Please note, run `npm run init` once per database, otherwise you'll see an error. If you get an error you can skip that step.
@@ -410,13 +409,7 @@ delete everything in your database**.
 
     ./tools/postgres/cleandb.sh
 
-Once that's done, you need to run the `init.sh` script again.
-
-    ./tools/postgres/init.sh
-
-Any migrations that you're aware of should also be run, the files can be found
-in the `./tools/postgres/migrate` directory. Running them sequentially will
-update the database's schema.
+Once that's done, you need to run `npm run init` again.
 
 You can also verify that the correct `midas` user exists for the `<TABLE_NAME>`.
 

--- a/config/migrations.js
+++ b/config/migrations.js
@@ -1,0 +1,3 @@
+module.exports.migrations = {
+  connection: 'postgresql'
+};

--- a/migrations/20160316223014-initial-schema.js
+++ b/migrations/20160316223014-initial-schema.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname + '/sqls/20160316223014-initial-schema-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname + '/sqls/20160316223014-initial-schema-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};

--- a/migrations/sqls/20160316223014-initial-schema-down.sql
+++ b/migrations/sqls/20160316223014-initial-schema-down.sql
@@ -1,0 +1,1 @@
+/* No downgrade from initial schema, but the up migration is idempotent. */

--- a/migrations/sqls/20160316223014-initial-schema-up.sql
+++ b/migrations/sqls/20160316223014-initial-schema-up.sql
@@ -1,0 +1,1674 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: attachment; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS attachment (
+    "fileId" integer,
+    "projectId" integer,
+    "taskId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: attachment_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE attachment_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: attachment_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE attachment_id_seq OWNED BY attachment.id;
+
+
+--
+-- Name: badge; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS badge (
+    "user" integer,
+    task integer,
+    id integer NOT NULL,
+    type character varying,
+    silent boolean DEFAULT false,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: badge_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE badge_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: badge_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE badge_id_seq OWNED BY badge.id;
+
+
+--
+-- Name: comment; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS comment (
+    topic boolean,
+    "projectId" integer,
+    "taskId" integer,
+    "parentId" integer,
+    "userId" integer,
+    value text,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: comment_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE comment_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: comment_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE comment_id_seq OWNED BY comment.id;
+
+
+--
+-- Name: delivery; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS delivery (
+    "notificationId" integer,
+    "deliveryDate" timestamp with time zone,
+    "deliveryType" text,
+    content text,
+    "isDelivered" boolean,
+    "isActive" boolean,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: delivery_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE delivery_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: delivery_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE delivery_id_seq OWNED BY delivery.id;
+
+
+--
+-- Name: event; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS event (
+    status text,
+    uuid text,
+    title text,
+    description text,
+    start timestamp with time zone,
+    "end" timestamp with time zone,
+    location text,
+    "userId" integer,
+    "projectId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: event_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE event_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: event_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE event_id_seq OWNED BY event.id;
+
+
+--
+-- Name: eventrsvp; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS eventrsvp (
+    "eventId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: eventrsvp_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE eventrsvp_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: eventrsvp_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE eventrsvp_id_seq OWNED BY eventrsvp.id;
+
+
+--
+-- Name: file; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS file (
+    "userId" integer,
+    name text,
+    "isPrivate" boolean,
+    "mimeType" text,
+    size integer,
+    data bytea,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone,
+    fd character varying
+);
+
+
+--
+-- Name: file_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE file_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: file_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE file_id_seq OWNED BY file.id;
+
+
+--
+-- Name: like; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS "like" (
+    "projectId" integer,
+    "taskId" integer,
+    "targetId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: like_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE like_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: like_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE like_id_seq OWNED BY "like".id;
+
+
+--
+-- Name: midas_user; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS midas_user (
+    username text,
+    name text,
+    title text,
+    bio text,
+    "photoId" integer,
+    "photoUrl" text,
+    "isAdmin" boolean,
+    disabled boolean,
+    "passwordAttempts" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone,
+    "completedTasks" integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: midas_user_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE midas_user_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: midas_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE midas_user_id_seq OWNED BY midas_user.id;
+
+
+--
+-- Name: migrations; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS migrations (
+    id integer NOT NULL,
+    name character varying(255) NOT NULL,
+    run_on timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: migrations_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE migrations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE migrations_id_seq OWNED BY migrations.id;
+
+
+--
+-- Name: notification; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS notification (
+    "callerId" integer,
+    "callerType" text,
+    "triggerGuid" text,
+    action text,
+    audience text,
+    "recipientId" integer,
+    "createdDate" timestamp with time zone,
+    "localParams" text,
+    "globalParams" text,
+    "isActive" boolean,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone,
+    model json
+);
+
+
+--
+-- Name: notification_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE notification_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: notification_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE notification_id_seq OWNED BY notification.id;
+
+
+--
+-- Name: passport; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS passport (
+    protocol text,
+    password text,
+    "accessToken" text,
+    provider text,
+    identifier text,
+    tokens json,
+    "user" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: passport_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE passport_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: passport_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE passport_id_seq OWNED BY passport.id;
+
+
+--
+-- Name: project; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS project (
+    state text,
+    title text,
+    description text,
+    "coverId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: project_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE project_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: project_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE project_id_seq OWNED BY project.id;
+
+
+--
+-- Name: project_tags__tagentity_projects; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS project_tags__tagentity_projects (
+    id integer NOT NULL,
+    project_tags integer,
+    tagentity_projects integer,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: project_tags__tagentity_projects_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE project_tags__tagentity_projects_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: project_tags__tagentity_projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE project_tags__tagentity_projects_id_seq OWNED BY project_tags__tagentity_projects.id;
+
+
+--
+-- Name: projectowner; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS projectowner (
+    "projectId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: projectowner_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE projectowner_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: projectowner_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE projectowner_id_seq OWNED BY projectowner.id;
+
+
+--
+-- Name: projectparticipant; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS projectparticipant (
+    "projectId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: projectparticipant_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE projectparticipant_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: projectparticipant_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE projectparticipant_id_seq OWNED BY projectparticipant.id;
+
+
+--
+-- Name: projecttag; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS projecttag (
+    "projectId" integer,
+    "tagId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: projecttag_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE projecttag_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: projecttag_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE projecttag_id_seq OWNED BY projecttag.id;
+
+
+--
+-- Name: schema; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS schema (
+    schema character varying,
+    version integer
+);
+
+
+--
+-- Name: session; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS session (
+    sid character varying NOT NULL,
+    sess json NOT NULL,
+    expire timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: tag; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS tag (
+    "projectId" integer,
+    "taskId" integer,
+    "tagId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: tag_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE tag_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: tag_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE tag_id_seq OWNED BY tag.id;
+
+
+--
+-- Name: tagentity; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS tagentity (
+    type text,
+    name text,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone,
+    data json
+);
+
+
+--
+-- Name: tagentity_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE tagentity_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: tagentity_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE tagentity_id_seq OWNED BY tagentity.id;
+
+
+--
+-- Name: tagentity_tasks__task_tags; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS tagentity_tasks__task_tags (
+    id integer NOT NULL,
+    tagentity_tasks integer,
+    task_tags integer,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: tagentity_tasks__task_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE tagentity_tasks__task_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: tagentity_tasks__task_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE tagentity_tasks__task_tags_id_seq OWNED BY tagentity_tasks__task_tags.id;
+
+
+--
+-- Name: tagentity_users__user_tags; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS tagentity_users__user_tags (
+    id integer NOT NULL,
+    tagentity_users integer,
+    user_tags integer,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: tagentity_users__user_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE tagentity_users__user_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: tagentity_users__user_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE tagentity_users__user_tags_id_seq OWNED BY tagentity_users__user_tags.id;
+
+
+--
+-- Name: task; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS task (
+    state text,
+    "userId" integer,
+    "projectId" integer,
+    title text,
+    description text,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone,
+    "publishedAt" timestamp with time zone,
+    "assignedAt" timestamp with time zone,
+    "completedAt" timestamp with time zone,
+    "completedBy" timestamp with time zone,
+    "submittedAt" timestamp with time zone
+);
+
+
+--
+-- Name: task_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE task_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: task_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE task_id_seq OWNED BY task.id;
+
+
+--
+-- Name: userauth; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS userauth (
+    "userId" integer,
+    provider text,
+    "providerId" text,
+    "accessToken" text,
+    "refreshToken" text,
+    "refreshTime" timestamp with time zone,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: userauth_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE userauth_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: userauth_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE userauth_id_seq OWNED BY userauth.id;
+
+
+--
+-- Name: useremail; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS useremail (
+    "userId" integer,
+    email text,
+    "isPrimary" boolean,
+    "isVerified" boolean,
+    token text,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: useremail_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE useremail_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: useremail_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE useremail_id_seq OWNED BY useremail.id;
+
+
+--
+-- Name: usernotification; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS usernotification (
+    "userId" integer,
+    "notificationId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: usernotification_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE usernotification_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: usernotification_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE usernotification_id_seq OWNED BY usernotification.id;
+
+
+--
+-- Name: userpassword; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS userpassword (
+    "userId" integer,
+    password text,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: userpassword_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE userpassword_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: userpassword_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE userpassword_id_seq OWNED BY userpassword.id;
+
+
+--
+-- Name: userpasswordreset; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS userpasswordreset (
+    "userId" integer,
+    token text,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: userpasswordreset_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE userpasswordreset_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: userpasswordreset_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE userpasswordreset_id_seq OWNED BY userpasswordreset.id;
+
+
+--
+-- Name: usersetting; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS usersetting (
+    "userId" integer,
+    context text,
+    key text,
+    value text,
+    "isActive" boolean,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone
+);
+
+
+--
+-- Name: usersetting_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE usersetting_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: usersetting_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE usersetting_id_seq OWNED BY usersetting.id;
+
+
+--
+-- Name: volunteer; Type: TABLE; Schema: public; Owner: midas; Tablespace:
+--
+
+CREATE TABLE IF NOT EXISTS volunteer (
+    "taskId" integer,
+    "userId" integer,
+    id integer NOT NULL,
+    "createdAt" timestamp with time zone,
+    "updatedAt" timestamp with time zone,
+    "deletedAt" timestamp with time zone,
+    silent boolean
+);
+
+
+--
+-- Name: volunteer_id_seq; Type: SEQUENCE; Schema: public; Owner: midas
+--
+
+DO
+$$
+BEGIN
+CREATE SEQUENCE volunteer_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+EXCEPTION WHEN duplicate_table THEN
+END
+$$ LANGUAGE plpgsql;
+
+
+--
+-- Name: volunteer_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: midas
+--
+
+ALTER SEQUENCE volunteer_id_seq OWNED BY volunteer.id;
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY attachment ALTER COLUMN id SET DEFAULT nextval('attachment_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY badge ALTER COLUMN id SET DEFAULT nextval('badge_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY comment ALTER COLUMN id SET DEFAULT nextval('comment_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY delivery ALTER COLUMN id SET DEFAULT nextval('delivery_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY event ALTER COLUMN id SET DEFAULT nextval('event_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY eventrsvp ALTER COLUMN id SET DEFAULT nextval('eventrsvp_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY file ALTER COLUMN id SET DEFAULT nextval('file_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY "like" ALTER COLUMN id SET DEFAULT nextval('like_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY midas_user ALTER COLUMN id SET DEFAULT nextval('midas_user_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY migrations ALTER COLUMN id SET DEFAULT nextval('migrations_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY notification ALTER COLUMN id SET DEFAULT nextval('notification_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY passport ALTER COLUMN id SET DEFAULT nextval('passport_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY project ALTER COLUMN id SET DEFAULT nextval('project_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY project_tags__tagentity_projects ALTER COLUMN id SET DEFAULT nextval('project_tags__tagentity_projects_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY projectowner ALTER COLUMN id SET DEFAULT nextval('projectowner_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY projectparticipant ALTER COLUMN id SET DEFAULT nextval('projectparticipant_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY projecttag ALTER COLUMN id SET DEFAULT nextval('projecttag_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY tag ALTER COLUMN id SET DEFAULT nextval('tag_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY tagentity ALTER COLUMN id SET DEFAULT nextval('tagentity_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY tagentity_tasks__task_tags ALTER COLUMN id SET DEFAULT nextval('tagentity_tasks__task_tags_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY tagentity_users__user_tags ALTER COLUMN id SET DEFAULT nextval('tagentity_users__user_tags_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY task ALTER COLUMN id SET DEFAULT nextval('task_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY userauth ALTER COLUMN id SET DEFAULT nextval('userauth_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY useremail ALTER COLUMN id SET DEFAULT nextval('useremail_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY usernotification ALTER COLUMN id SET DEFAULT nextval('usernotification_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY userpassword ALTER COLUMN id SET DEFAULT nextval('userpassword_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY userpasswordreset ALTER COLUMN id SET DEFAULT nextval('userpasswordreset_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY usersetting ALTER COLUMN id SET DEFAULT nextval('usersetting_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: midas
+--
+
+ALTER TABLE ONLY volunteer ALTER COLUMN id SET DEFAULT nextval('volunteer_id_seq'::regclass);
+
+
+--
+-- Name: attachment_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE attachment DROP CONSTRAINT IF EXISTS attachment_pkey;
+ALTER TABLE ONLY attachment
+    ADD CONSTRAINT attachment_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: comment_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE comment DROP CONSTRAINT IF EXISTS comment_pkey;
+ALTER TABLE ONLY comment
+    ADD CONSTRAINT comment_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: delivery_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE delivery DROP CONSTRAINT IF EXISTS delivery_pkey;
+ALTER TABLE ONLY delivery
+    ADD CONSTRAINT delivery_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: event_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE event DROP CONSTRAINT IF EXISTS event_pkey;
+ALTER TABLE ONLY event
+    ADD CONSTRAINT event_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: eventrsvp_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE eventrsvp DROP CONSTRAINT IF EXISTS eventrsvp_pkey;
+ALTER TABLE ONLY eventrsvp
+    ADD CONSTRAINT eventrsvp_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: file_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE file DROP CONSTRAINT IF EXISTS file_pkey;
+ALTER TABLE ONLY file
+    ADD CONSTRAINT file_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: like_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE "like" DROP CONSTRAINT IF EXISTS like_pkey;
+ALTER TABLE ONLY "like"
+    ADD CONSTRAINT like_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: midas_user_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE midas_user DROP CONSTRAINT IF EXISTS midas_user_pkey;
+ALTER TABLE ONLY midas_user
+    ADD CONSTRAINT midas_user_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: midas_user_username_key; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE midas_user DROP CONSTRAINT IF EXISTS midas_user_username_key;
+ALTER TABLE ONLY midas_user
+    ADD CONSTRAINT midas_user_username_key UNIQUE (username);
+
+
+--
+-- Name: migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE migrations DROP CONSTRAINT IF EXISTS migrations_pkey;
+ALTER TABLE ONLY migrations
+    ADD CONSTRAINT migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notification_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE notification DROP CONSTRAINT IF EXISTS notification_pkey;
+ALTER TABLE ONLY notification
+    ADD CONSTRAINT notification_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: passport_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE passport DROP CONSTRAINT IF EXISTS passport_pkey;
+ALTER TABLE ONLY passport
+    ADD CONSTRAINT passport_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE project DROP CONSTRAINT IF EXISTS project_pkey;
+ALTER TABLE ONLY project
+    ADD CONSTRAINT project_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_tags__tagentity_projects_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE project_tags__tagentity_projects DROP CONSTRAINT IF EXISTS project_tags__tagentity_projects_pkey;
+ALTER TABLE ONLY project_tags__tagentity_projects
+    ADD CONSTRAINT project_tags__tagentity_projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projectowner_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE projectowner DROP CONSTRAINT IF EXISTS projectowner_pkey;
+ALTER TABLE ONLY projectowner
+    ADD CONSTRAINT projectowner_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projectparticipant_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE projectparticipant DROP CONSTRAINT IF EXISTS projectparticipant_pkey;
+ALTER TABLE ONLY projectparticipant
+    ADD CONSTRAINT projectparticipant_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projecttag_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE projecttag DROP CONSTRAINT IF EXISTS projecttag_pkey;
+ALTER TABLE ONLY projecttag
+    ADD CONSTRAINT projecttag_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: session_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE session DROP CONSTRAINT IF EXISTS session_pkey;
+ALTER TABLE ONLY session
+    ADD CONSTRAINT session_pkey PRIMARY KEY (sid);
+
+
+--
+-- Name: tag_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE tag DROP CONSTRAINT IF EXISTS tag_pkey;
+ALTER TABLE ONLY tag
+    ADD CONSTRAINT tag_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tagentity_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE tagentity DROP CONSTRAINT IF EXISTS tagentity_pkey;
+ALTER TABLE ONLY tagentity
+    ADD CONSTRAINT tagentity_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tagentity_tasks__task_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE tagentity_tasks__task_tags DROP CONSTRAINT IF EXISTS tagentity_tasks__task_tags_pkey;
+ALTER TABLE ONLY tagentity_tasks__task_tags
+    ADD CONSTRAINT tagentity_tasks__task_tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tagentity_users__user_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE tagentity_users__user_tags DROP CONSTRAINT IF EXISTS tagentity_users__user_tags_pkey;
+ALTER TABLE ONLY tagentity_users__user_tags
+    ADD CONSTRAINT tagentity_users__user_tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE task DROP CONSTRAINT IF EXISTS task_pkey;
+ALTER TABLE ONLY task
+    ADD CONSTRAINT task_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: userauth_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE userauth DROP CONSTRAINT IF EXISTS userauth_pkey;
+ALTER TABLE ONLY userauth
+    ADD CONSTRAINT userauth_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: useremail_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE useremail DROP CONSTRAINT IF EXISTS useremail_pkey;
+ALTER TABLE ONLY useremail
+    ADD CONSTRAINT useremail_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: usernotification_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE usernotification DROP CONSTRAINT IF EXISTS usernotification_pkey;
+ALTER TABLE ONLY usernotification
+    ADD CONSTRAINT usernotification_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: userpassword_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE userpassword DROP CONSTRAINT IF EXISTS userpassword_pkey;
+ALTER TABLE ONLY userpassword
+    ADD CONSTRAINT userpassword_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: userpasswordreset_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE userpasswordreset DROP CONSTRAINT IF EXISTS userpasswordreset_pkey;
+ALTER TABLE ONLY userpasswordreset
+    ADD CONSTRAINT userpasswordreset_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: usersetting_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE usersetting DROP CONSTRAINT IF EXISTS usersetting_pkey;
+ALTER TABLE ONLY usersetting
+    ADD CONSTRAINT usersetting_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: volunteer_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
+--
+ALTER TABLE volunteer DROP CONSTRAINT IF EXISTS volunteer_pkey;
+ALTER TABLE ONLY volunteer
+    ADD CONSTRAINT volunteer_pkey PRIMARY KEY (id);

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "build": "$npm_package_config_grunt build",
     "start": "npm run check-migrate && node app.js",
     "migrate": "$npm_package_config_grunt db:migrate:up",
-    "check-migrate": "$npm_package_config_grunt db:migrate:up --dry-run | sed -rn 's/.*Processed migration (.*)/\\x1b[41m[WARNING] Pending Migration: \\1\\x1b[0m (Run `npm run migrate`)/p'",
+    "check-migrate": "$npm_package_config_grunt db:migrate:up --dry-run | perl -ne 's/.*Processed migration (.*)/\\x1b[41m[WARNING] Pending Migration: \\1\\x1b[0m (Run `npm run migrate`)/ && print'",
     "init": "npm run migrate && node test/init/init/init.test.js",
     "demo": "npm run migrate && mocha test/test.upstart.js --development --recursive test/demo",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",

--- a/package.json
+++ b/package.json
@@ -66,10 +66,13 @@
   "devDependencies": {
     "casper-chai": "^0.2.1",
     "casperjs": "1.1.0-beta3",
+    "db-migrate": "0.10.0-beta.11",
+    "db-migrate-pg": "0.1.9",
     "mocha-casperjs": "0.5.3",
     "nodemon": "^1.3.7",
     "pg": "~3.6.0",
-    "phantomjs": "^1.9.16"
+    "phantomjs": "^1.9.16",
+    "sails-db-migrate": "1.3.1"
   },
   "config": {
     "grunt": "./node_modules/sails/node_modules/.bin/grunt",
@@ -77,18 +80,19 @@
   },
   "scripts": {
     "preinstall": "if [ \"$THEME\" ]; then git clone $THEME _theme; npm run import --openopps-platform:dir=_theme; fi",
-    "install": "npm run build",
+    "install": "npm run migrate && npm run build",
     "test:api": "mocha test/test.upstart.js --recursive test/api",
     "test:browser": "npm run build && node test/browser/upstart.js",
     "test:unit": "mocha test/test.upstart.js --recursive test/unit",
     "test": "npm run test:unit && npm run test:api && npm run test:browser",
     "build": "$npm_package_config_grunt build",
-    "start": "node app.js",
-    "migrate": "./tools/postgres/init.sh",
-    "init": "node test/init/init/init.test.js",
-    "demo": "mocha test/test.upstart.js --development --recursive test/demo",
+    "start": "npm run check-migrate && node app.js",
+    "migrate": "$npm_package_config_grunt db:migrate:up",
+    "check-migrate": "$npm_package_config_grunt db:migrate:up --dry-run | sed -rn 's/.*Processed migration (.*)/\\x1b[41m[WARNING] Pending Migration: \\1\\x1b[0m (Run `npm run migrate`)/p'",
+    "init": "npm run migrate && node test/init/init/init.test.js",
+    "demo": "npm run migrate && mocha test/test.upstart.js --development --recursive test/demo",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
-    "watch": "source .env | true && nodemon --watch assets --watch api --watch config --watch views -i assets/build -e js,html,css"
+    "watch": "npm run check-migrate && source .env | true && nodemon --watch assets --watch api --watch config --watch views -i assets/build -e js,html,css"
   },
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
Replace use of SQL scripts run through psql to handle database
migrations with sails-db-migrate.  New migration scripts are written in
javascript.

Create an initial migration script which will load the initial schema.
(It can also be run against existing databases.)

Update the `migrate` npm task to run the new db-migrate migration
scripts.

Update the `init`, `install`, `demo` npm tasks to perform any pending
database migrations.

Update the `start` and `watch` npm tasks to warn the user about pending
migrations.

Update the Travis CI configuration to create the midas database since
`npm install` now runs the database migrations.

*See #1248 and https://micropurchase.18f.gov/auctions/17*