### PR TITLE
pull request for issue 1230: When I create a Full-Time Detail, I would like to see some helper text

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -16,7 +16,11 @@ See [i18next](http://i18next.com/) for more information on configuration and use
 
 ## Customizing UI
 
-edit ```assets/js/backbone/config/ui.json``` which allows customization of UI features, currently the only feature that can be configured is the ability to turn off the ability to have Projects (which serve as a way to group Opportunities/tasks).  To hide the project UI, simply change "show" to ```false```.
+edit ```assets/js/backbone/config/ui.json``` which allows customization of UI features. Currently you can configure the following features:
+
+### Hide Projects
+
+It is possible to turn off the ability to have Projects (which serve as a way to group Opportunities/tasks).  To hide the project UI, simply change "show" to ```false```.
 
 ```
 {
@@ -25,6 +29,21 @@ edit ```assets/js/backbone/config/ui.json``` which allows customization of UI fe
   }
 }
 ```
+
+### Full Time Detail Sample Text
+
+When the user creates or edits a task and selects "Full Time Detail" in Step 1 (What type of effort is needed?), the sample text will be added to the task description, if there was no previous description text. There is also an extra link available (Show Default Description) that shows the sample text once it is clicked. The link is not available if the 'Full Time Detail' sample text is not setup.
+
+The value of the description field supports markdown with links and formatting. The description field in the ui.json config file does not support a multiline string; newlines should be escaped as \n.
+
+```
+{
+  "fullTimeDetail": {
+    "description": "Default description **Full Time Detail**.... \n\n_Awesome!_\n\nLinks are also supported: [i18next](http://i18next.com/)."
+  }
+}
+```
+
 
 ## Bulk Import of Tag Data
 
@@ -51,10 +70,10 @@ The state of a Project or Opportunity controls it's visibility in certain views 
 These states are listed in ```assets/js/backbone/config/ui.json```.
 ```
 "states" :
-		{
-		 "value": "open",
-		 "label": "Open"
-		},...
+    {
+     "value": "open",
+     "label": "Open"
+    },...
 ```
 
 Changing the value of label is largely cosmetic as it is used to drive drop downs and other display information. If you change the value of value and do not change code to support it midas will behave in an inconsitent manner.

--- a/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
+++ b/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
@@ -33,30 +33,6 @@
 <div class="col-md-9 tight-box">
 
   <div class="form-group">
-    <h3>Headline</h3>
-    <p>Write a few words that describe what needs to happen, inspires someone about the outcome, or entices them to learn something new.</p>
-    <p><em>(Maximum of 100 characters)</em></p>
-    <input id="task-title" type="text" placeholder="A short description of the problem." value="<%- data.title %>" class="form-control input-lg validate" data-validate="empty,count100"/>
-    <span class="help-block error-empty" style="display:none;">You must enter a title for this <span data-i18n="task">opportunity</span></span>
-    <span class="help-block error-count100" style="display:none;">The short description of the problem must be less than 100 characters.</span>
-  </div>
-
-  <div class="form-group">
-    <h3>Description</h3>
-    <p>Write a description that explains the <span data-i18n="task">opportunity</span>. Add details so that people can imagine what this will be like when completed.</p>
-    <p><em>(There is no limit on length, but we recommend 200 words or less.)</em></p>
-    <div class="markdown-edit"></div>
-    <span class="help-block error-empty" style="display:none;">You must enter a description for this <span data-i18n="task">opportunity</span></span>
-  </div>
-
-  <div class="form-group">
-    <h3>Tags</h3>
-    <p>Create tags using keywords that describe the opportunity. Include the focus area, mission of the work and skills they will develop through as part of the <span data-i18n="task">opportunity</span>.</p>
-    <p><em>(Put a comma between each one. Example: Cyber Security, Research, employee engagement)</em></p>
-    <input type="hidden" id="task_tag_skills" class="task-skills fullwidth"/>
-  </div>
-
-  <div class="form-group">
     <label for="time-required">
       <h3>What type of effort is needed?</h3>
     </label>
@@ -64,7 +40,7 @@
       <div class="radio">
         <label>
           <% var selected = madlibTags['task-time-required'] && (madlibTags['task-time-required'][0].id == t.id); %>
-          <input type="radio" name="task-time-required" value="<%- t.id %>"
+          <input type="radio" name="task-time-required" value="<%- t.id %>" data-descr="<%- t.name %>"
             <% if (selected) { %>checked<%}%> >
           <%- t.name %><% if (t.description) { %> &mdash; <%= t.description %> <% } %>
         </label>
@@ -125,6 +101,30 @@
     </select>
   </div>
 
+  <div class="form-group">
+    <h3>Headline</h3>
+    <p>Write a few words that describe what needs to happen, inspires someone about the outcome, or entices them to learn something new.</p>
+    <p><em>(Maximum of 100 characters)</em></p>
+    <input id="task-title" type="text" placeholder="A short description of the problem." value="<%- data.title %>" class="form-control input-lg validate" data-validate="empty,count100"/>
+    <span class="help-block error-empty" style="display:none;">You must enter a title for this <span data-i18n="task">opportunity</span></span>
+    <span class="help-block error-count100" style="display:none;">The short description of the problem must be less than 100 characters.</span>
+  </div>
+
+  <div class="form-group">
+    <h3>Description</h3>
+    <p>Write a description that explains the <span data-i18n="task">opportunity</span>. Add details so that people can imagine what this will be like when completed. <span class="show-markdown"></span>
+    </p>
+    <p><em>(There is no limit on length, but we recommend 200 words or less.)</em></p>
+    <div class="markdown-edit"></div>
+    <span class="help-block error-empty" style="display:none;">You must enter a description for this <span data-i18n="task">opportunity</span></span>
+  </div>
+
+  <div class="form-group">
+    <h3>Tags</h3>
+    <p>Create tags using keywords that describe the opportunity. Include the focus area, mission of the work and skills they will develop through as part of the <span data-i18n="task">opportunity</span>.</p>
+    <p><em>(Put a comma between each one. Example: Cyber Security, Research, employee engagement)</em></p>
+    <input type="hidden" id="task_tag_skills" class="task-skills fullwidth"/>
+  </div>
 </div>
 <div class="col-md-3">
   <div class="box equal-box">

--- a/assets/js/backbone/apps/tasks/new/templates/task_form_template.html
+++ b/assets/js/backbone/apps/tasks/new/templates/task_form_template.html
@@ -7,90 +7,10 @@
 </div>
 <p>Optional fields are indicated.</p>
 <form id="task-form" class="create--task" action="/api/task">
+
   <fieldset id="step-1">
     <legend>
-      <span>Step 1 - Create a Headline</span>
-    </legend>
-    <div class="form-group fullwidth">
-      <div class="row">
-        <div class="col-md-8">
-          <label for="task-title">
-            <span class="create__label">Headline</span>
-            <span>Write a few words that describe what needs to happen, inspires someone about the outcome, or entices them to learn something new.</span>
-            <span><em>(Maximum of 100 characters)</em></span>
-          </label>
-          <span class="help-block error-empty" style="display:none;">You must enter headline for this <span
-              data-i18n="task">opportunity</span></span>
-          <span class="help-block error-count100" style="display:none;">The short description of the problem must be less than 100 characters.</span>
-          <input type="text"
-                 id="task-title"
-                 class="fullwidth form-control validate"
-                 data-validate="empty,count100"/>
-
-        </div>
-        <div class="col-md-4">
-          <aside>
-            <h4>Headline examples:</h4>
-            <p>Team up to Produce a Set of Videos About the Nat'l Networking for Manufacturing Innovation</p>
-            <p>Let your inner "Data Detective" Out and Get to Know Arizona</p>
-          </aside>
-        </div>
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset id="step-2">
-    <legend>
-      <span>Step 2 - Describe the <span data-i18n="Task">opportunity</span></span>
-    </legend>
-    <div class="form-group fullwidth">
-      <div class="row">
-        <div class="col-md-8">
-          <label for="task-description">
-            <span class="create__label">Description</span>
-            <span>Write a description that explains the <span data-i18n="task">opportunity</span>. Add details so that people can imagine what this will be like when completed.</span>
-            <span><em>(There is no limit on length, but we recommend 200 words or less.)</em></span>
-          </label>
-          <span class="help-block error-empty" style="display:none;">You must enter a description for this <span data-i18n="task">opportunity</span></span>
-          <div class="markdown-edit"></div>
-        </div>
-        <div class="col-md-4">
-          <aside>
-              <h4>Make an inspiring <span data-i18n="task">opportunity</span> by including:</h4>
-              <ul>
-                <li>Why is this important?</li>
-                <li>What does success look like?</li>
-                <li>Who will benefit?</li>
-                <li>How does this fit into the bigger picture?</li>
-              </ul>
-          </aside>
-        </div>
-      </div>
-      <div class="row tag-row">
-        <div class="col-md-8">
-          <label for="skills">
-            <span class="create__label">Tags</span>
-            <span>Create tags using keywords that describe the opportunity. Include the focus area, mission of the work and skills they will develop through as part of the <span data-i18n="task">opportunity</span>.</span>
-            <span><em>(Put a comma between each one. Example: Cyber Security, Research, employee engagement)</em></span>
-          </label>
-          <div>
-            <input type="hidden" id="js-task-tag" name="skills" class="fullwidth" />
-          </div>
-        </div>
-        <div class="col-md-4">
-          <aside>
-            <h4>What are tags?</h4>
-            <p>Tags are helpful data we add to <span data-i18n="tasks">opportunities</span>. Users can quickly find what interests them by looking at the tags.</p>
-            <p>They can also use them to search for matching opportunities.</p>
-          </aside>
-        </div>
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset id="step-3">
-    <legend>
-      <span>Step 3 - Define Who, When, and Where</span>
+      <span>Step 1 - Define Who, When, and Where</span>
     </legend>
     <div class="form-group fullwidth">
       <div class="row">
@@ -101,7 +21,7 @@
           <% _.each(tags['task-time-required'], function (time) { %>
             <div class="radio">
               <label>
-                <input type="radio" name="task-time-required" value="<%- time.id %>">
+                <input type="radio" name="task-time-required" value="<%- time.id %>" data-descr="<%- time.name %>">
                 <%- time.name %><% if (time.description) { %> &mdash; <%= time.description %> <% } %>
               </label>
             </div>
@@ -187,6 +107,88 @@
           </select>
         </div>
         <div class="col-md-4"></div>
+      </div>
+    </div>
+  </fieldset>
+
+
+  <fieldset id="step-2">
+    <legend>
+      <span>Step 2 - Create a Headline</span>
+    </legend>
+    <div class="form-group fullwidth">
+      <div class="row">
+        <div class="col-md-8">
+          <label for="task-title">
+            <span class="create__label">Headline</span>
+            <span>Write a few words that describe what needs to happen, inspires someone about the outcome, or entices them to learn something new.</span>
+            <span><em>(Maximum of 100 characters)</em></span>
+          </label>
+          <span class="help-block error-empty" style="display:none;">You must enter headline for this <span
+              data-i18n="task">opportunity</span></span>
+          <span class="help-block error-count100" style="display:none;">The short description of the problem must be less than 100 characters.</span>
+          <input type="text"
+                 id="task-title"
+                 class="fullwidth form-control validate"
+                 data-validate="empty,count100"/>
+
+        </div>
+        <div class="col-md-4">
+          <aside>
+            <h4>Headline examples:</h4>
+            <p>Team up to Produce a Set of Videos About the Nat'l Networking for Manufacturing Innovation</p>
+            <p>Let your inner "Data Detective" Out and Get to Know Arizona</p>
+          </aside>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset id="step-3">
+    <legend>
+      <span>Step 3 - Describe the <span data-i18n="Task">opportunity</span></span>
+    </legend>
+    <div class="form-group fullwidth">
+      <div class="row">
+        <div class="col-md-8">
+          <label for="task-description">
+            <span class="create__label">Description</span>
+            <span>Write a description that explains the <span data-i18n="task">opportunity</span>. Add details so that people can imagine what this will be like when completed. <span class="show-markdown"></span></span>
+            <span><em>(There is no limit on length, but we recommend 200 words or less.)</em></span>
+          </label>
+          <div class="markdown-edit"></div>
+          <span class="help-block error-empty" style="display:none;">You must enter a description for this <span data-i18n="task">opportunity</span></span>
+        </div>
+        <div class="col-md-4">
+          <aside>
+              <h4>Make an inspiring <span data-i18n="task">opportunity</span> by including:</h4>
+              <ul>
+                <li>Why is this important?</li>
+                <li>What does success look like?</li>
+                <li>Who will benefit?</li>
+                <li>How does this fit into the bigger picture?</li>
+              </ul>
+          </aside>
+        </div>
+      </div>
+      <div class="row tag-row">
+        <div class="col-md-8">
+          <label for="skills">
+            <span class="create__label">Tags</span>
+            <span>Create tags using keywords that describe the opportunity. Include the focus area, mission of the work and skills they will develop through as part of the <span data-i18n="task">opportunity</span>.</span>
+            <span><em>(Put a comma between each one. Example: Cyber Security, Research, employee engagement)</em></span>
+          </label>
+          <div>
+            <input type="hidden" id="js-task-tag" name="skills" class="fullwidth" />
+          </div>
+        </div>
+        <div class="col-md-4">
+          <aside>
+            <h4>What are tags?</h4>
+            <p>Tags are helpful data we add to <span data-i18n="tasks">opportunities</span>. Users can quickly find what interests them by looking at the tags.</p>
+            <p>They can also use them to search for matching opportunities.</p>
+          </aside>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/assets/js/backbone/apps/tasks/new/views/task_form_view.js
+++ b/assets/js/backbone/apps/tasks/new/views/task_form_view.js
@@ -7,17 +7,19 @@ var MarkdownEditor = require('../../../../components/markdown_editor');
 var TaskModel = require('../../../../entities/tasks/task_model');
 var TaskFormTemplate = require('../templates/task_form_template.html');
 var TagFactory = require('../../../../components/tag_factory');
+var ShowMarkdownMixin = require('../../../../components/show_markdown_mixin');
 
 var TaskFormView = Backbone.View.extend({
 
   el: '#container',
 
   events: {
-    'change .validate'                :  'v',
-    'click [name=task-time-required]' :  'toggleTimeOptions',
-    'change #task-location'           :  'locationChange',
-    'click #js-task-draft'            :  'saveDraft',
-    'click #js-task-create'           :  'submit',
+    'change .validate'                : 'v',
+    'click [name=task-time-required]' : 'toggleTimeOptions',
+    'change #task-location'           : 'locationChange',
+    'click #js-task-draft'            : 'saveDraft',
+    'click #js-task-create'           : 'submit',
+    'change [name=task-time-required]': 'timeRequiredChanged',
   },
 
   /*
@@ -75,7 +77,7 @@ var TaskFormView = Backbone.View.extend({
             data = _.sortBy(data, 'updatedAt');
           }
           else if (type === 'task-time-required') {
-            data = _.chain(data).filter(function(item) {
+            data = _.chain(data).filter(function (item) {
               // if an agency is included in the data of a tag
               // then restrict it to users who are also
               // in that agency
@@ -85,20 +87,20 @@ var TaskFormView = Backbone.View.extend({
               return false;
             }).map(function (item) {
               if (item.name == 'One time') {
-                item.description = 'A one time task with a defined timeline'
+                item.description = 'A one time task with a defined timeline';
               }
               else if (item.name == 'Ongoing') {
-                item.description = 'Requires a portion of participant’s time until a goal is reached'
+                item.description = 'Requires a portion of participant’s time until a goal is reached';
               }
               return item;
             }).value();
           }
           self.tagSources[type] = data;
-        }
+        },
       });
     };
 
-    async.each(types, requestAllTagsByType, function (err) {
+    async.each(types, requestAllTagsByType, function () {
       self.render();
     });
   },
@@ -139,6 +141,12 @@ var TaskFormView = Backbone.View.extend({
     this.$el.html( template );
     this.initializeSelect2();
     this.initializeTextArea();
+    this.initializeShowMarkdown({
+      el               : '.show-markdown',
+      id               : 'show-default-description',
+      displayCondition : 'Full Time Detail',
+      textAreaId       : 'task-description',
+    });
 
     this.$( '#time-options' ).css( 'display', 'none' );
 
@@ -427,5 +435,7 @@ var TaskFormView = Backbone.View.extend({
   },
 
 });
+
+_.extend(TaskFormView.prototype, ShowMarkdownMixin);
 
 module.exports = TaskFormView;

--- a/assets/js/backbone/components/show_markdown.html
+++ b/assets/js/backbone/components/show_markdown.html
@@ -1,0 +1,2 @@
+<a href="#" id="<%- id %>"></a>
+<div class="preview-description" style="display: none;"></div>

--- a/assets/js/backbone/components/show_markdown.js
+++ b/assets/js/backbone/components/show_markdown.js
@@ -1,0 +1,76 @@
+
+var _ = require('underscore');
+var marked = require('marked');
+var BaseComponent = require('../base/base_component');
+var Template = require('./show_markdown.html');
+
+module.exports = BaseComponent.extend({
+
+  events: {
+    'click #show-default-description' : 'clickLink'
+  },
+
+  initialize: function (options) {
+    this.options = options;
+    return this;
+  },
+
+  render: function () {
+    var self = this;
+    var data = {
+      id   : self.options.id,
+      data : self.options.data
+    };
+    var template = _.template(Template)(data);
+    self.$el.html(template);
+    return self;
+  },
+
+  showHide: function (descr) {
+    var self = this;
+    if (self.options.data.length > 0 &&  descr === 'Full Time Detail') {
+      self.$('#' + self.options.id).text('Show Default Description');
+      self.$('#show-default-description').show();
+      self.setTextAreaText(self.options.data);
+    } else {
+      self.$('#show-default-description').hide();
+      self.$('.preview-description').hide();
+    }
+    return self;
+  },
+
+  setTextAreaText: function (text) {
+    var self = this;
+    var currentText = $('textarea#' + self.options.textAreaId).val().trim();
+    if (currentText.length === 0 && text) {
+      $('#' + self.options.textAreaId).val(text);
+      validate({ currentTarget: '#' + self.options.textAreaId });
+    }
+    return self;
+  },
+
+  clickLink: function (e) {
+    var self = this;
+    if (e.preventDefault) e.preventDefault();
+
+    if (self.$('.preview-description').is(':visible')) {
+      self.$('.preview-description').hide();
+      self.$('#' + self.options.id).text('Show Default Description');
+    } else {
+      // Render the preview using marked.
+      marked.setOptions({
+        gfm    : true,
+        breaks : true
+      });
+      var html = marked(self.options.data);
+      self.$('.preview-description').html(html);
+      self.$('#' + self.options.id).text('Hide Default Description');
+      self.$('.preview-description').show();
+    }
+  },
+
+  cleanup: function () {
+    removeView(this);
+  }
+
+});

--- a/assets/js/backbone/components/show_markdown_mixin.js
+++ b/assets/js/backbone/components/show_markdown_mixin.js
@@ -1,0 +1,26 @@
+var UIConfig = require('../config/ui.json');
+var _ = require('underscore');
+var ShowMarkdown = require('../components/show_markdown');
+
+module.exports = {
+  initializeShowMarkdown: function (options) {
+    if (this.defaultDescription) { this.defaultDescription.cleanup(); }
+    var data = (UIConfig.fullTimeDetail && UIConfig.fullTimeDetail.description) ? UIConfig.fullTimeDetail.description : undefined;
+    if (data) {
+      options = _.extend(options, { data: data });
+      this.defaultDescription = new ShowMarkdown(options).render();
+      var descr = this.$('input[name="task-time-required"]:checked').attr('data-descr');
+      this.defaultDescription.showHide(descr);
+    }
+  },
+
+  timeRequiredChanged: function (e) {
+    e.preventDefault();
+    if (this.defaultDescription) {
+      var descr = this.$(e.currentTarget).attr('data-descr');
+      this.defaultDescription.showHide(descr);
+    }
+    return this;
+  },
+
+};

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -45,5 +45,8 @@
   ],
   "modalHome" : {
     "show" : false
+  },
+  "fullTimeDetail": {
+    "description": "Default description for **Full Time Detail**.... \n\n_Awesome!_\n\nLinks are also supported: [i18next](http://i18next.com/)."
   }
 }

--- a/assets/styles/modules/task/_base.scss
+++ b/assets/styles/modules/task/_base.scss
@@ -186,4 +186,5 @@ aside a:focus {
         'modules/task/infinite-scroll',
         'modules/task/list',
         'modules/task/attachments',
-        'modules/task/markdown-editor';
+        'modules/task/markdown-editor',
+        'modules/task/show-markdown';

--- a/assets/styles/modules/task/_show-markdown.scss
+++ b/assets/styles/modules/task/_show-markdown.scss
@@ -1,0 +1,6 @@
+.preview-description {
+  margin-top: 10px;
+  border-style: solid none;
+  border-width: 1px 0;
+  border-color: #e0e0e0;
+}

--- a/test/browser/taskActions.test.js
+++ b/test/browser/taskActions.test.js
@@ -69,6 +69,49 @@ describe('Task actions', function () {
       casper.click('.add-opportunity');
     });
 
+    // Check steps.
+    casper.then(function () {
+      var step1 = casper.fetchText('#step-1 legend span'),
+        step2 = casper.fetchText('#step-2 legend span'),
+        step3 = casper.fetchText('#step-3 legend span').substr(0, 33);
+      assert.equal('Step 1 - Define Who, When, and Where', step1);
+      assert.equal('Step 2 - Create a Headline', step2);
+      assert.equal('Step 3 - Describe the Opportunity', step3);
+    });
+
+    // Check Full Time Details radio button.
+    var selFullTimeDetail = 'input[type=radio][name=task-time-required][data-descr="Full Time Detail"]';
+    casper.then(function () {
+      if (casper.exists(selFullTimeDetail)) {
+        assert.ok(true);
+      } else {
+        assert.ok(false);
+      }
+    });
+
+    // Click "Full Time Detail"
+    casper.then(function () {
+      casper.click(selFullTimeDetail);
+      casper.waitForSelector('a[id=show-default-description]');
+    });
+
+    // Click "Show Default Description"
+    casper.then(function () {
+      casper.click('a[id=show-default-description]');
+      var preview = casper.getHTML('.preview-description').substr(0,60);
+      assert.equal('<p>Default description for <strong>Full Time Detail</strong>', preview);
+    });
+
+    // Click "Part Time", link should not be visible.
+    casper.then(function () {
+      casper.click('input[type=radio][name=task-time-required][data-descr="Part Time"]');
+      if (casper.visible('a[id=show-default-description]')) {
+        assert.ok(false);
+      } else {
+        assert.ok(true);
+      }
+    });
+
     // Fill out the form
     casper.then(function () {
       casper.fillSelectors('#task-form', {
@@ -94,12 +137,46 @@ describe('Task actions', function () {
     });
   });
 
+
   it('should edit task', function () {
 
     // Click the edit task button
     casper.then(function () {
       casper.click('#task-edit');
       casper.waitForSelector('#task-edit-form');
+    });
+
+    // Check Full Time Details radio button.
+    var selFullTimeDetail = 'input[type=radio][name=task-time-required][data-descr="Full Time Detail"]';
+    casper.then(function () {
+      if (casper.exists(selFullTimeDetail)) {
+        assert.ok(true);
+      } else {
+        assert.ok(false);
+      }
+    });
+
+    // Click "Full Time Detail"
+    casper.then(function () {
+      casper.click(selFullTimeDetail);
+      casper.waitForSelector('a[id=show-default-description]');
+    });
+
+    // Click "Show Default Description"
+    casper.then(function () {
+      casper.click('a[id=show-default-description]');
+      var preview = casper.getHTML('.preview-description').substr(0,60);
+      assert.equal('<p>Default description for <strong>Full Time Detail</strong>', preview);
+    });
+
+    // Click "Part Time", link should not be visible.
+    casper.then(function () {
+      casper.click('input[type=radio][name=task-time-required][data-descr="Part Time"]');
+      if (casper.visible('a[id=show-default-description]')) {
+        assert.ok(false);
+      } else {
+        assert.ok(true);
+      }
     });
 
     // Change the title and description
@@ -122,6 +199,8 @@ describe('Task actions', function () {
     });
 
   });
+
+
 
   it('should change opportunity state', function () {
 

--- a/test/data/disk.db
+++ b/test/data/disk.db
@@ -766,7 +766,15 @@
         "createdAt": "2015-05-08T21:45:52.593Z",
         "updatedAt": "2015-05-08T21:45:52.593Z",
         "id": 34
+      },
+      {
+        "type": "task-time-required",
+        "name": "Full Time Detail",
+        "createdAt": "2016-03-16T21:45:35.901Z",
+        "updatedAt": "2016-03-16T21:45:35.901Z",
+        "id": 35
       }
+
     ],
     "task": [
       {


### PR DESCRIPTION
<img width="1234" alt="screen shot 2016-03-17 at 16 29 52" src="https://cloud.githubusercontent.com/assets/244419/13855384/7e22cc12-ec70-11e5-86bc-0f39e71cc15c.png">

@ultrasaurus the .travis.yml has been removed from the PR. Above is the screenshot from Travis for your reference. Please let me know what you think!

Thanks,
Ronald