### PR TITLE
Add Agency Admin User Role

### DIFF
--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -213,6 +213,27 @@ module.exports = {
   },
 
   /**
+   * Add or remove agency admin privileges from a user account
+   * @param id the user id to make an agency admin or remove
+   * @param action true to make agency admin, false to revoke
+   * eg: /api/admin/agencyAdmin/:id?action=true
+   */
+  agencyAdmin: function (req, res) {
+    if (!req.route.params.id) {
+      return res.send(400, { message: 'Must specify a user id for this action.' });
+    }
+    User.findOneById(req.route.params.id, function (err, user) {
+      if (err) { return res.send(400, { message: 'An error occurred looking up this user.', error: err }); }
+      user.isAgencyAdmin = (req.param('action') === 'true');
+      user.save(function (err) {
+        if (err) { return res.send(400, { message: 'An error occurred changing admin status for this user.', error: err }); }
+        return res.send(user);
+      });
+    });
+  },
+
+
+  /**
    * Unlock a user's account by resetting their password attempts
    * @param id the user id to clear password attempts
    */
@@ -701,6 +722,13 @@ module.exports = {
 
     } );
 
+  },
+
+  // Get an agency
+  agency: function (req, res) {
+    var requestedAgencyId = req.route.params.id;
+    // Future work: Figure out requirements
+    res.send({ requestedAgency: requestedAgencyId });
   },
 
   /**

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -39,6 +39,12 @@ module.exports = {
       defaultsTo: false
     },
 
+    // User is an admin for their agency
+    isAgencyAdmin: {
+      type: 'BOOLEAN',
+      defaultsTo: false
+    },
+
     // is the user's login disabled
     disabled: {
       type: 'BOOLEAN',

--- a/api/policies/agencyAdmin.js
+++ b/api/policies/agencyAdmin.js
@@ -1,0 +1,21 @@
+var _ = require('underscore');
+/**
+* Check whether user is admin or agency admin for the agency requested
+*/
+module.exports = function admin (req, res, next) {
+  // Check the user is logged in and is an admin
+  if (!req.user) {
+    return res.send(403, "You must login as an admin or agency admin to perform this action.");
+  }
+  if (req.user[0].isAdmin) {
+    return next();
+  }
+  var userAgency = _.findWhere(req.user[0].tags, { type: 'agency' });
+  var userAgencyId = userAgency.id;
+  var requestedAgencyId = req.route.params.id;
+  if (requestedAgencyId == userAgencyId) {
+    return next();
+  }
+  return res.send(403, "You must login as an admin or agency admin to perform this action.");
+};
+

--- a/api/policies/protectAdmin.js
+++ b/api/policies/protectAdmin.js
@@ -1,10 +1,12 @@
 /**
-* Only Admins should be able to UPDATE the isAdmin property of the model.
-* All other references to isAdmin should be scrubbed.
+* Only Admins should be able to UPDATE the isAdmin and isAgencyAdmin properties
+* of the model.  All other references to isAdmin and isAgencyAdmin should be
+* scrubbed.
 */
 module.exports = function protectAdmin (req, res, next) {
   if ( !(req.user && req.user[0].isAdmin) ) {
     delete req.body.isAdmin;
+    delete req.body.isAgencyAdmin;
   }
   next();
 };

--- a/assets/js/backbone/apps/admin/templates/admin_agencies_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_agencies_template.html
@@ -1,0 +1,11 @@
+<div class="alert alert-danger" style="display:none;">
+</div>
+<div class="row">
+  <div class="col-md-12 box box-pad-lr">
+    <div class="row">
+      <div class="col-md-12 box-pad-b">
+        <h2>Coming Soon</h2>
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/js/backbone/apps/admin/templates/admin_main_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_main_template.html
@@ -18,6 +18,7 @@
         <ul class="nav navbar-nav">
           <li><a href="/admin/dashboard" class="link-admin" data-target="dashboard">Dashboard</a></li>
           <li><a href="/admin/users" class="link-admin" data-target="user">User Management</a></li>
+          <li><a href="/admin/agencies" class="link-admin" data-target="agencies">My Agency</a></li>
           <li><a href="/admin/tags" class="link-admin" data-target="tag">Tag Configuration</a></li>
           <li><a href="/admin/tasks" class="link-admin" data-target="tasks">Tasks</a></li>
           <li><a href="/admin/participants" class="link-admin" data-target="participants">Participants</a></li>
@@ -32,6 +33,8 @@
     <div class="admin-container" id="admin-tag">
     </div>
     <div class="admin-container" id="admin-task">
+    </div>
+    <div class="admin-container" id="admin-agencies">
     </div>
     <div class="admin-container" id="admin-participants">
       <div class="fullwidth text-center spinner">

--- a/assets/js/backbone/apps/admin/templates/admin_user_table.html
+++ b/assets/js/backbone/apps/admin/templates/admin_user_table.html
@@ -13,6 +13,7 @@
       <th class="admin-user-checkbox">Password</th>
       <% } %>
       <th class="admin-user-checkbox">Admin</th>
+      <th class="admin-user-checkbox">Agency Admin</th>
     </tr>
   </thead>
   <tbody>
@@ -71,6 +72,11 @@
       <td>
         <button type="button" class="btn btn-default btn-xs admin-user-rmadmin" data-toggle="tooltip" data-placement="top" title="Remove Admin Privileges" <% if (u.isAdmin !== true) { %>style="display:none;"<% } %>><i class="fa fa-check icon-green icon-center"></i></button>
         <button type="button" class="btn btn-default btn-xs admin-user-mkadmin" data-toggle="tooltip" data-placement="top" title="Make Admin" <% if (u.isAdmin === true) { %>style="display:none;"<% } %>><i class="fa fa-times-circle icon-red icon-center"></i></button>
+        <button type="button" class="btn btn-default btn-xs btn-spin" style="display:none;"><i class="fa fa-spin fa-spinner icon-center"></i></button>
+      </td>
+      <td>
+        <button type="button" class="btn btn-default btn-xs admin-user-rm-agencyadmin" data-toggle="tooltip" data-placement="top" title="Remove Agency Admin Privileges" <% if (u.isAgencyAdmin !== true) { %>style="display:none;"<% } %>><i class="fa fa-check icon-green icon-center"></i></button>
+        <button type="button" class="btn btn-default btn-xs admin-user-mk-agencyadmin" data-toggle="tooltip" data-placement="top" title="Make Agency Admin" <% if (u.isAgencyAdmin === true) { %>style="display:none;"<% } %>><i class="fa fa-times-circle icon-red icon-center"></i></button>
         <button type="button" class="btn btn-default btn-xs btn-spin" style="display:none;"><i class="fa fa-spin fa-spinner icon-center"></i></button>
       </td>
     </tr>

--- a/assets/js/backbone/apps/admin/views/admin_agencies_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_agencies_view.js
@@ -1,0 +1,45 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+var AdminAgenciesTemplate = require('../templates/admin_agencies_template.html');
+
+
+var AdminAgenciesView = Backbone.View.extend({
+
+  events: {
+  },
+
+  initialize: function (options) {
+    this.options = options;
+    this.data = {
+      agency: _(window.cache.currentUser.tags).findWhere({ type: 'agency' })
+    };
+  },
+
+  render: function () {
+    var self = this;
+
+    this.$el.show();
+
+    $.ajax({
+      url: '/api/admin/agency/' + this.data.agency.id,
+      dataType: 'json',
+      success: function (data) {
+        var template = _.template(AdminAgenciesTemplate, {
+          variable: 'data'
+        })(data);
+        self.$el.html(template);
+      }
+    });
+
+    Backbone.history.navigate('/admin/agencies/' + this.data.agency.id);
+    return this;
+  },
+
+  cleanup: function () {
+    removeView(this);
+  }
+
+});
+
+module.exports = AdminAgenciesView;
+

--- a/assets/js/backbone/apps/admin/views/admin_main_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_main_view.js
@@ -5,6 +5,7 @@ var utils = require('../../../mixins/utilities');
 var AdminUserView = require('./admin_user_view');
 var AdminTagView = require('./admin_tag_view');
 var AdminTaskView = require('./admin_task_view');
+var AdminAgenciesView = require('./admin_agencies_view');
 var AdminParticipantsView = require('./admin_participants_view');
 var AdminDashboardView = require('./admin_dashboard_view');
 var AdminMainTemplate = require('../templates/admin_main_template.html');
@@ -28,9 +29,21 @@ var AdminMainView = Backbone.View.extend({
     return this;
   },
 
+  isAdmin: function () {
+    return !!(window.cache.currentUser && window.cache.currentUser.isAdmin);
+  },
+
+  isAgencyAdmin: function () {
+    return !!(window.cache.currentUser && window.cache.currentUser.isAgencyAdmin);
+  },
+
   routeTarget: function (target) {
     if (!target) {
       target = 'dashboard';
+    }
+    // If agency admin, display My Agency page
+    if (!this.isAdmin() && this.isAgencyAdmin()) {
+      target = 'agencies';
     }
     var t = $((this.$("[data-target=" + target + "]"))[0]);
     // remove active classes
@@ -55,6 +68,12 @@ var AdminMainView = Backbone.View.extend({
       }
       this.hideOthers();
       this.adminTaskView.render();
+    } else if (target == 'agencies') {
+      if (!this.adminAgenciesView) {
+        this.initializeAdminAgenciesView();
+      }
+      this.hideOthers();
+      this.adminAgenciesView.render();
     } else if (target == 'participants') {
       if (!this.adminParticipantsView) {
         this.initializeAdminParticipantsView();
@@ -104,6 +123,15 @@ var AdminMainView = Backbone.View.extend({
     }
     this.adminTaskView = new AdminTaskView({
       el: "#admin-task"
+    });
+  },
+
+  initializeAdminAgenciesView: function () {
+    if (this.adminAgenciesView) {
+      this.adminAgenciesView.cleanup();
+    }
+    this.adminAgenciesView = new AdminAgenciesView({
+      el: "#admin-agencies"
     });
   },
 

--- a/assets/js/backbone/apps/admin/views/admin_user_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_user_view.js
@@ -11,16 +11,18 @@ var LoginConfig = require('../../../config/login.json');
 
 var AdminUserView = Backbone.View.extend({
 
-  events: {
-    "click a.page"              : "clickPage",
-    "click .link-backbone"      : linkBackbone,
-    "click .admin-user-mkadmin" : "adminCreate",
-    "click .admin-user-rmadmin" : "adminRemove",
-    "click .admin-user-enable"  : "adminEnable",
-    "click .admin-user-disable" : "adminDisable",
-    "click .admin-user-unlock"  : "adminUnlock",
-    "click .admin-user-resetpw" : "resetPassword",
-    "keyup #user-filter"        : "filter"
+  events                               : {
+    "click a.page"                     : "clickPage",
+    "click .link-backbone"             : linkBackbone,
+    "click .admin-user-mkadmin"        : "adminCreate",
+    "click .admin-user-rmadmin"        : "adminRemove",
+    "click .admin-user-mk-agencyadmin" : "agencyAdminCreate",
+    "click .admin-user-rm-agencyadmin" : "agencyAdminRemove",
+    "click .admin-user-enable"         : "adminEnable",
+    "click .admin-user-disable"        : "adminDisable",
+    "click .admin-user-unlock"         : "adminUnlock",
+    "click .admin-user-resetpw"        : "resetPassword",
+    "keyup #user-filter"               : "filter"
   },
 
   initialize: function (options) {
@@ -144,6 +146,28 @@ var AdminUserView = Backbone.View.extend({
     });
   },
 
+  agencyAdminCreate: function (e) {
+    if (e.preventDefault) e.preventDefault();
+    var t = $(e.currentTarget);
+    var id = $(t.parents('tr')[0]).data('id');
+    this.updateUser(t, {
+      id: id,
+      isAgencyAdmin: true,
+      url: '/api/admin/agencyAdmin/' + id + '?action=true'
+    });
+  },
+
+  agencyAdminRemove: function (e) {
+    if (e.preventDefault) e.preventDefault();
+    var t = $(e.currentTarget);
+    var id = $(t.parents('tr')[0]).data('id');
+    this.updateUser(t, {
+      id: id,
+      isAgencyAdmin: false,
+      url: '/api/admin/agencyAdmin/' + id + '?action=false'
+    });
+  },
+
   adminEnable: function (e) {
     if (e.preventDefault) e.preventDefault();
     var t = $(e.currentTarget);
@@ -202,6 +226,12 @@ var AdminUserView = Backbone.View.extend({
           }
           if (data.isAdmin === false) {
             $(t.siblings(".admin-user-mkadmin")[0]).show();
+          }
+          if (data.isAgencyAdmin === true) {
+            $(t.siblings(".admin-user-rm-agencyadmin")[0]).show();
+          }
+          if (data.isAgencyAdmin === false) {
+            $(t.siblings(".admin-user-mk-agencyadmin")[0]).show();
           }
         }
       });

--- a/config/policies.js
+++ b/config/policies.js
@@ -28,7 +28,8 @@ module.exports.policies = {
 
   // Only admins can access the AdminController API
   AdminController : {
-    '*': ['passport', 'authenticated', 'admin']
+    '*': ['passport', 'authenticated', 'admin'],
+    'agency': ['passport', 'authenticated', 'agencyAdmin']
   },
 
   // Auth controller can be accessed by anyone

--- a/package.json
+++ b/package.json
@@ -64,12 +64,16 @@
     "grunt-sass": "^1.1.0"
   },
   "devDependencies": {
+    "browserify-shim": "3.8.12",
     "casper-chai": "^0.2.1",
     "casperjs": "1.1.0-beta3",
+    "jquery": "2.2.2",
     "mocha-casperjs": "0.5.3",
+    "mochify": "2.17.0",
     "nodemon": "^1.3.7",
     "pg": "~3.6.0",
-    "phantomjs": "^1.9.16"
+    "phantomjs": "^1.9.16",
+    "sinon": "1.17.3"
   },
   "config": {
     "grunt": "./node_modules/sails/node_modules/.bin/grunt",
@@ -81,7 +85,8 @@
     "test:api": "mocha test/test.upstart.js --recursive test/api",
     "test:browser": "npm run build && node test/browser/upstart.js",
     "test:unit": "mocha test/test.upstart.js --recursive test/unit",
-    "test": "npm run test:unit && npm run test:api && npm run test:browser",
+    "test:client": "mochify --recursive --transform browserify-shim --transform stringify -r jquery ./test/client",
+    "test": "npm run test:unit && npm run test:api && npm run test:browser && npm run test:client",
     "build": "$npm_package_config_grunt build",
     "start": "node app.js",
     "migrate": "./tools/postgres/init.sh",
@@ -89,6 +94,17 @@
     "demo": "mocha test/test.upstart.js --development --recursive test/demo",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
     "watch": "source .env | true && nodemon --watch assets --watch api --watch config --watch views -i assets/build -e js,html,css"
+  },
+  "browser": {
+    "jquery": "./assets/js/vendor/jquery.min.js",
+    "bootstrap": "./node_modules/bootstrap/dist/js/bootstrap.js"
+  },
+  "browserify-shim": {
+    "bootstrap": {
+      "depends": [
+        "jquery:jQuery"
+      ]
+    }
   },
   "main": "app.js",
   "repository": {

--- a/test/api/sails/admin.test.js
+++ b/test/api/sails/admin.test.js
@@ -34,6 +34,26 @@ describe('admin:', function () {
       );
     });
 
+    it('set agency admin', function (done) {
+      request.get(
+        { url: conf.url + '/admin/agencyAdmin/1?action=true' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 403);
+          done(err);
+        }
+      );
+    });
+
+    it('remove agency admin', function (done) {
+      request.get(
+        { url: conf.url + '/admin/agencyAdmin/1?action=false' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 403);
+          done(err);
+        }
+      );
+    });
+
     it('get users', function (done) {
       request.get(
         { url: conf.url + '/admin/users' },
@@ -75,6 +95,47 @@ describe('admin:', function () {
           var b = JSON.parse(body);
           assert.equal(b.id, 2);
           assert.equal(b.isAdmin, false);
+          done(err);
+        }
+      );
+    });
+
+    it('set agency admin', function (done) {
+      request.get(
+        { url: conf.url + '/admin/agencyAdmin/2?action=true' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          assert.equal(b.id, 2);
+          assert.isTrue(b.isAgencyAdmin);
+          done(err);
+        }
+      );
+    });
+
+    it('remove agency admin', function (done) {
+      request.get(
+        { url: conf.url + '/admin/agencyAdmin/2?action=false' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          assert.equal(b.id, 2);
+          assert.equal(b.isAgencyAdmin, false);
+          done(err);
+        }
+      );
+    });
+
+    it('get agency', function (done) {
+      request.get(
+        { url: conf.url + '/admin/agency/1' },
+        function (err, response, body) {
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          // This endpoint is currently just a placeholder that echoes back the
+          // agency id
+          assert.isDefined(b.requestedAgency);
+          assert.equal(b.requestedAgency, '1');
           done(err);
         }
       );

--- a/test/client/backbone/apps/admin/views/admin_agencies_view.js
+++ b/test/client/backbone/apps/admin/views/admin_agencies_view.js
@@ -1,0 +1,49 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var AdminAgenciesView = require('../../../../../../assets/js/backbone/apps/admin/views/admin_agencies_view.js');
+var Backbone = require('backbone');
+var jquery = require('jquery');
+// Expose jQuery to views, which currently assume it exists on global window object
+window.$ = jquery;
+
+describe('AdminAgenciesView', function () {
+  beforeEach(function () {
+    window.cache = {
+      currentUser: {
+        tags: [
+          { type: 'agency', id: 1 },
+        ],
+      },
+    };
+  });
+
+  it('should initialize user\'s agency', function () {
+    var view = new AdminAgenciesView();
+    assert.equal(view.data.agency.id, 1, 'agency id');
+  });
+
+  describe('render', function () {
+    beforeEach(function () {
+      sinon.stub($, 'ajax');
+      sinon.stub(Backbone.history, 'navigate');
+    });
+
+    afterEach(function () {
+      $.ajax.restore();
+      Backbone.history.navigate.restore();
+    });
+
+    it('should fetch user\'s agency', function () {
+      var view = new AdminAgenciesView();
+      view.render();
+      assert($.ajax.called, 'XHR requested');
+      assert($.ajax.firstCall.args[0].url, '/api/admin/agency/1', 'user\'s agency request');
+    });
+
+    it('should update the URL', function () {
+      var view = new AdminAgenciesView();
+      view.render();
+      assert(Backbone.history.navigate.calledWith('/admin/agencies/1'), 'updated URL');
+    });
+  });
+});

--- a/test/client/backbone/apps/admin/views/admin_main_view.js
+++ b/test/client/backbone/apps/admin/views/admin_main_view.js
@@ -1,0 +1,158 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var AdminMainView = require('../../../../../../assets/js/backbone/apps/admin/views/admin_main_view.js');
+var AdminAgenciesView = require('../../../../../../assets/js/backbone/apps/admin/views/admin_agencies_view.js');
+var jquery = require('jquery');
+// Expose jQuery to views, which currently assume it exists on global window object
+window.$ = jquery;
+
+describe('AdminMainView', function () {
+  var adminMainView;
+  beforeEach(function () {
+    adminMainView = new AdminMainView();
+    window.cache = {
+      currentUser: {
+        isAdmin: false,
+        isAgencyAdmin: false,
+      },
+    };
+  });
+
+  describe('isAdmin', function () {
+    it('should check currentUser', function () {
+      assert(!adminMainView.isAdmin(), 'not an admin');
+      window.cache.currentUser.isAdmin = true;
+      assert(adminMainView.isAdmin(), 'user is an admin');
+    });
+  });
+
+  describe('isAgencyAdmin', function () {
+    it('should check currentUser', function () {
+      var adminMainView = new AdminMainView();
+      assert(!adminMainView.isAgencyAdmin(), 'not an agency admin');
+      window.cache.currentUser.isAgencyAdmin = true;
+      assert(adminMainView.isAgencyAdmin(), 'user is an agency admin');
+    });
+  });
+
+  describe('routeTarget', function () {
+    var adminAgenciesView;
+    beforeEach(function () {
+      adminAgenciesView = new AdminAgenciesView();
+      sinon.stub(adminMainView, 'initializeAdminAgenciesView', function () {
+        adminMainView.adminAgenciesView = adminAgenciesView;
+      });
+      sinon.stub(adminAgenciesView, 'render');
+    });
+
+    describe('when user is not an admin', function () {
+      beforeEach(function () {
+        sinon.stub(adminMainView, 'isAdmin').returns(false);
+      });
+
+      afterEach(function () {
+        adminMainView.isAdmin.restore();
+      });
+
+      describe('when user is an agency admin', function () {
+        beforeEach(function () {
+          sinon.stub(adminMainView, 'isAgencyAdmin').returns(true);
+        });
+
+        afterEach(function () {
+          adminMainView.isAgencyAdmin.restore();
+        });
+
+        it('should render agency view by default', function () {
+          adminMainView.routeTarget();
+          assert(adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(adminAgenciesView.render.called, 'agency view rendered');
+        });
+
+        it('should allow agency view to be rendered explicitly', function () {
+          adminMainView.routeTarget('agencies');
+          assert(adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(adminAgenciesView.render.called, 'agency view rendered');
+        });
+      });
+
+      describe('when user is not an agency admin', function () {
+        // lack of authorization is handled after API calls fail
+        beforeEach(function () {
+          sinon.stub(adminMainView, 'isAgencyAdmin').returns(false);
+        });
+
+        afterEach(function () {
+          adminMainView.isAgencyAdmin.restore();
+        });
+
+        it('should not render agency view by default', function () {
+          adminMainView.routeTarget();
+          assert(!adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(!adminAgenciesView.render.called, 'agency view rendered');
+        });
+
+        it('should allow agency view to be rendered explicitly', function () {
+          adminMainView.routeTarget('agencies');
+          assert(adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(adminAgenciesView.render.called, 'agency view rendered');
+        });
+
+      });
+    });
+
+    describe('when user is an admin', function () {
+      beforeEach(function () {
+        sinon.stub(adminMainView, 'isAdmin').returns(true);
+      });
+
+      afterEach(function () {
+        adminMainView.isAdmin.restore();
+      });
+
+      describe('when user is an agency admin', function () {
+        beforeEach(function () {
+          sinon.stub(adminMainView, 'isAgencyAdmin').returns(true);
+        });
+
+        afterEach(function () {
+          adminMainView.isAgencyAdmin.restore();
+        });
+
+        it('should not render agency view by default', function () {
+          adminMainView.routeTarget();
+          assert(!adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(!adminAgenciesView.render.called, 'agency view rendered');
+        });
+
+        it('should allow agency view to be rendered', function () {
+          adminMainView.routeTarget('agencies');
+          assert(adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(adminAgenciesView.render.called, 'agency view rendered');
+        });
+      });
+
+      describe('when user is not an agency admin', function () {
+        beforeEach(function () {
+          sinon.stub(adminMainView, 'isAgencyAdmin').returns(false);
+        });
+
+        afterEach(function () {
+          adminMainView.isAgencyAdmin.restore();
+        });
+
+        it('should not render agency view by default', function () {
+          adminMainView.routeTarget();
+          assert(!adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(!adminAgenciesView.render.called, 'agency view rendered');
+        });
+
+        it('should allow agency view to be rendered', function () {
+          adminMainView.routeTarget('agencies');
+          assert(adminMainView.initializeAdminAgenciesView.called, 'agency view initialized');
+          assert(adminAgenciesView.render.called, 'agency view rendered');
+        });
+      });
+    });
+  });
+});

--- a/test/client/backbone/apps/admin/views/admin_user_view.js
+++ b/test/client/backbone/apps/admin/views/admin_user_view.js
@@ -1,0 +1,40 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var AdminUserView = require('../../../../../../assets/js/backbone/apps/admin/views/admin_user_view.js');
+var jquery = require('jquery');
+// Expose jQuery to views, which currently assume it exists on global window object
+window.$ = jquery;
+
+describe('AdminUserView', function () {
+  var clickEvent, button, adminUserView;
+  beforeEach(function () {
+    adminUserView = new AdminUserView();
+    var table = jquery('<table><tr data-id="1"><td><button/></td></tr></table>');
+    button = table.find('button')[0];
+    clickEvent = {
+      currentTarget: button,
+      preventDefault: sinon.spy(),
+    };
+    sinon.stub(adminUserView, 'updateUser');
+  });
+
+  describe('agencyAdminCreate', function () {
+    it('should update the user with the isAgencyAdmin flag', function () {
+      adminUserView.agencyAdminCreate(clickEvent);
+      assert.equal(adminUserView.updateUser.firstCall.args[0][0], button, 'button clicked');
+      assert.equal(adminUserView.updateUser.firstCall.args[1].id, '1', 'user id');
+      assert.equal(adminUserView.updateUser.firstCall.args[1].isAgencyAdmin, true, 'isAgencyAdmin flag');
+      assert.equal(adminUserView.updateUser.firstCall.args[1].url, '/api/admin/agencyAdmin/1?action=true', 'url to request');
+    });
+  });
+
+  describe('agencyAdminRemove', function () {
+    it('should remove the isAgencyAdmin flag from the user', function () {
+      adminUserView.agencyAdminRemove(clickEvent);
+      assert.equal(adminUserView.updateUser.firstCall.args[0][0], button, 'button clicked');
+      assert.equal(adminUserView.updateUser.firstCall.args[1].id, '1', 'user id');
+      assert.equal(adminUserView.updateUser.firstCall.args[1].isAgencyAdmin, false, 'isAgencyAdmin flag');
+      assert.equal(adminUserView.updateUser.firstCall.args[1].url, '/api/admin/agencyAdmin/1?action=false', 'url to request');
+    });
+  });
+});

--- a/tools/postgres/migrate/13.sh
+++ b/tools/postgres/migrate/13.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Add a column to indicate user is an agency admin
+psql $DATABASE_URL -c "ALTER TABLE midas_user ADD COLUMN "isAgencyAdmin" boolean;"
+psql $DATABASE_URL -c "UPDATE midas_user SET \"isAgencyAdmin\" = 'f'";
+psql $DATABASE_URL -c "UPDATE schema SET version = 13 WHERE schema = 'current';"

--- a/tools/postgres/schema/current.sql
+++ b/tools/postgres/schema/current.sql
@@ -363,6 +363,7 @@ CREATE TABLE midas_user (
     "photoId" integer,
     "photoUrl" text,
     "isAdmin" boolean,
+    "isAgencyAdmin" boolean,
     disabled boolean,
     "passwordAttempts" integer,
     id integer NOT NULL,


### PR DESCRIPTION
Add new Agency Admin user role.  Agency admins will be able to manage
their agency (not yet implemented).

Update the database schema and User model to add an isAgencyAdmin flag
to users.

Update the User Management admin page to allow admins to toggle the
Agency Admin permission.

Update the Sails Admin controller with a new placeholder `agency` API
endpoint.

Add a new `agencyAdmin` policy to restrict access to admins and agency
admins.

Update the `protectAdmin` policy to only allow admins to modify the
`isAgencyAdmin` flag.

Add a new placeholder My Agency page at /admin/agencies/:id.

Update the Backbone admin main view to redirect Agency Admin users to
the new My Agency page.

*See #1229 and https://micropurchase.18f.gov/auctions/20*