### PR TITLE
text updates, per feedback from GSA OHRM

### DIFF
--- a/assets/js/backbone/apps/admin/templates/admin_task_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_task_template.html
@@ -96,7 +96,7 @@
                            class="js-tip js-task-open"
                            data-toggle="tooltip"
                            data-placement="top"
-                           data-original-title="Open Task">
+                           data-original-title="Publish Task">
                          <span class='fa fa-check'></span>
                         </a>
                         <a href="#delete/<%- task.id %>"

--- a/assets/js/backbone/apps/admin/views/admin_task_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_task_view.js
@@ -61,7 +61,7 @@ var AdminTaskView = Backbone.View.extend({
 
       success: function ( model, response, options ) {
 
-        var userConfirmed = window.confirm( 'Are you sure you want to open "' + model.attributes.title + '"?' );
+        var userConfirmed = window.confirm( 'Are you sure you want to publish "' + model.attributes.title + '"?' );
 
         if ( userConfirmed ) {
 

--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -44,7 +44,7 @@
               None
             <% } %>
           </div>
-          <h2>Time Committment</h2>
+          <h2>Time Commitment</h2>
           <div>
             <% if (madlibTags['task-time-required']) { %>   <!-- One-time, On-going, Full-Time Detail -->
               <%= madlibTags['task-time-required'][0].name %>

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -47,6 +47,6 @@
     "show" : false
   },
   "fullTimeDetail": {
-    "description": "**Description:** What is the _impact_ of this opportunity? What kind of _experience_ will someone gain from the work? You can add links to provide [more info](https://www.usa.gov/)\n\n**Title/Series/Grade:** fill in _requirements_ for this position (or _Unclassified Duties_ if there are no specific title or grade requirements)\n\n**Service/Staff Office:**\n\n**Region:**\n\n"
+    "description": "**Description:**\n\n**Series/Grade (or Unclassified Duties):**\n\n**PD Number (if required):**\n\n**Preferred Start Date:**\n\n**Detail Length (up to 120 days):**\n\n**Skills Required:**\n\n"
   }
 }


### PR DESCRIPTION
update text for full-detail description #1274
As an admin, it's confusing to see "Open Task" --> publish makes more sense #1277
also: fix typo: "Time Committment" -> "Time Commitment"