### PR TITLE
Fix many notifications, some test coverage

### DIFF
--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -28,6 +28,7 @@ module.exports = {
   update: function (req, res) {
     sails.log.verbose("update task:",req.body)
     var taskId = req.params.id
+    req.body.id = taskId;
     Task.update({id: taskId}, req.body)
     .then(function(tasks) {
       res.status(200);    // created

--- a/api/models/Badge.js
+++ b/api/models/Badge.js
@@ -58,6 +58,7 @@ module.exports = {
   // if the badge was not explicitly set to be silent
   // send out a notification to the user
   afterCreate: function(model, done) {
+    sails.log.verbose('Badge afterCreate', model);
     if (model.silent === true) return done();
 
     User.find({ id: model.user }).exec(function(err, users) {
@@ -143,15 +144,13 @@ module.exports = {
     var badge   = { user: userId },
         counter = { ongoing: 0, oneTime: 0 },
         ongoingTaskId, oneTimeTaskId;
-
+    sails.log.verbose('awardForTaskPublish (user tasks)', userId, tasks)
     // Check if the badge update should be occurring silently by checking the `opts`.
     badge.silent = ( opts && ! _.isUndefined( opts.silent ) ) ? opts.silent : false;
 
     // Catch if `opts` is an actual callback and reassign it to `done`.
     if ( _.isFunction( opts ) && _.isUndefined( done ) ) {
-
       done = opts;
-
     }
 
     tasks.forEach(function(t) {
@@ -178,13 +177,15 @@ module.exports = {
     }
 
     if (badge.type) {
-      Badge.findOrCreate(badge, badge, function(err, b){
+      Badge.findOrCreate(badge, badge, function(err, b) {
         b = [b];
         // swallow a potential error (expected) that the badge
         // already exists
         if (err && err._e.toString().match('Badge already exists')) {
           err = null;
           b = [];
+        } else {
+          sails.log.verbose('awardForTaskPublish badge created (badge)', b)
         }
         if (err) sails.log.error(err);
         if (done) return done(err, b);

--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -1,8 +1,3 @@
-var fs = require('fs'),
-    nodemailer = require('nodemailer'),
-    protocol = sails.config.emailProtocol,
-    transportConfig = sails.config[protocol.toLowerCase()];
-
 /**
  * Notification
  *
@@ -10,6 +5,10 @@ var fs = require('fs'),
  * @description :: A representation of a user-directed message
  * @docs		:: http://sailsjs.org/#!documentation/models
  */
+ var fs = require('fs'),
+     nodemailer = require('nodemailer'),
+     protocol = sails.config.emailProtocol,
+     transportConfig = sails.config[protocol.toLowerCase()];
 
 module.exports = {
 
@@ -61,8 +60,15 @@ module.exports = {
     @param {object} model triggering the notification
     @param {sting} the triggering model's type
   */
-  trigger: function (notification) {
-    sails.log.debug( notification );
+  trigger: function(notification, done) {
+    if (typeof done === "undefined") done = function() {};
+    // Send mail over SMTP with node-mailer
+    if (protocol === '') {
+      sails.log.info('email OFF, would have sent:', notification);
+      return done(null);
+    } else {
+      sails.log.debug( notification );      
+    }
 
     // Get notification script
     var path = __dirname + '/../notifications/' +
@@ -72,6 +78,7 @@ module.exports = {
     // Populate notification data
     template.data(notification.model, function (err, data) {
       if (err) sails.log.error(err);
+      if (err) return done(err);
 
       // Set notification action on the data object
       data._action = notification.action;
@@ -86,8 +93,11 @@ module.exports = {
 
       // Render and send notification
       Notification.render(template, data, function (err, options) {
+        if (err) return done(err);
         Notification.send(options, function (err, info) {
+          if (err) sails.log.error(err);
           if (info) sails.log.info(info);
+          return done(err, info);
         });
       });
 
@@ -112,16 +122,16 @@ module.exports = {
     // Template html content
     fs.readFile(html, function (err, template) {
       if (err) sails.log.error(err);
+      if (err) return done(err);
       data._content = _.template(template)(data);
 
       // Inject template html into layout
       fs.readFile(layout, function (err, layout) {
         if (err) sails.log.error(err);
         mailOptions.html = _.template(layout)(data);
-        done(err, mailOptions);
+        return done(err, mailOptions);
       });
     });
-
   },
 
   // Send an email
@@ -139,17 +149,12 @@ module.exports = {
       sails.config.notificationsBCC
     ]);
 
-    // Send mail over SMTP with node-mailer
-    if (protocol === '') {
-      sails.log.info('email OFF, would have sent:', options);
-    } else {
-      sails.log.info('Sending SMTP message', options);
-      this._transport.sendMail(options, function (err, info) {
-        if (err) sails.log.error('Failed to send mail. If this is unexpected, ' +
-          'please check your email configuration in config/local.js.', err);
-        if (done) return done(err, info);
-      });
-    }
+    sails.log.info('Sending SMTP message', options);
+    this._transport.sendMail(options, function (err, info) {
+      if (err) sails.log.error('Failed to send mail. If this is unexpected, ' +
+        'please check your email configuration in config/local.js.', err);
+      if (done) return done(err, info);
+    });
   },
 
   // Mailer transport

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -91,6 +91,27 @@ module.exports = {
     }
     done();
   },
+
+  beforeCreate: function(values, done) {
+    // If configured, validate that user has an email from a valid domain
+    if (sails.config.validateDomains && sails.config.domains) {
+      var domains = sails.config.domains.map(function(domain) {
+            return new RegExp(domain.replace(/\./g, '\.') + '$');
+          });
+      if (!_.find(domains, function(domain) {
+        return domain.test(values.username.split('@')[1]);
+      })) return done('invalid domain');
+    }
+    done();
+  },
+
+  afterCreate: function(model, done) {
+    Notification.create({
+      action: 'user.create.welcome',
+      model: model
+    }, done);
+  },
+
   // Note: this can be used to create admin users
   // relies on filtering in controller actions for safety
   register: function(attributes, done) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "connect-pg-simple": "^3.1.0",
     "connect-redis": "^3.0.2",
     "csv-parse": "^1.0.4",
+    "csvtojson": "^0.5.6",
     "db-migrate": "^0.10.0-beta.11",
     "db-migrate-pg": "^0.1.9",
     "ejs": "2.3.4",

--- a/test/fixtures/task.js
+++ b/test/fixtures/task.js
@@ -15,72 +15,62 @@ module.exports = {
     title: '',
     description: '',
     userId: 1,
-    publishedAt: '2015-05-08T21:45:55.823Z',
-    createdAt: '2015-05-08T21:45:55.823Z',
-    updatedAt: '2015-05-08T21:45:55.823Z',
   },
   'submitted': {
     state: 'submitted',
     title: '',
     description: '',
     userId: 1,
-    publishedAt: '2015-05-08T21:45:55.823Z',
-    createdAt: '2015-05-08T21:45:55.823Z',
-    updatedAt: '2015-05-08T21:45:55.823Z',
   },
   'open': {
     state: 'open',
     title: 'Validate USDA Data',
     description: 'Some addresses in the USDA Meat & Poultry Inspection Directory need validating and correcting to ensure they can be leveraged for geospatial mapping. You will determine if the address is suitable for mapping or mailing. Get a quick intro to geo-spatial analysis and help make food inspection more efficient.',
     userId: 1,
-    publishedAt: '2015-05-08T21:45:55.823Z',
-    createdAt: '2015-05-08T21:45:55.823Z',
-    updatedAt: '2015-05-08T21:45:55.823Z',
   },
   'assigned': {
     state: 'assigned',
     title: 'Assigned Task',
     description: 'description of the assigned task',
     userId: 1,
-    publishedAt: '2015-05-08T21:45:55.823Z',
-    createdAt: '2015-05-08T21:45:55.823Z',
-    updatedAt: '2015-05-08T21:45:55.823Z',
   },
   'completed': {
     state: 'completed',
     title: 'Completed Task',
     description: 'description of the completed task',
     userId: 1,
-    publishedAt: '2015-05-08T21:45:55.823Z',
-    createdAt: '2015-05-08T21:45:55.823Z',
-    updatedAt: '2015-05-08T21:45:55.823Z',
   },
   'archived': {
     state: 'archived',
     title: 'Archived Task',
     description: 'description of the archived task',
     userId: 1,
-    publishedAt: '2015-05-08T21:45:55.823Z',
-    createdAt: '2015-05-08T21:45:55.823Z',
-    updatedAt: '2015-05-08T21:45:55.823Z',
+  },
+  'oneTimeSubmitted': {
+    title: 'Fake one time task',
+    state: 'submitted',
+    userId: 1,
+    tags: [tags.oneTime]
   },
   'oneTime': {
     title: 'Fake one time task',
+    userId: 1,
     tags: [tags.oneTime]
   },
   'anotherTime': {
     title: 'Second fake one time task',
+    userId: 1,
     tags: [tags.oneTime]
   },
   'ongoing': {
     title: 'Fake ongoing task',
+    userId: 1,
     tags: [tags.ongoing]
   },
   'anotherOngoing': {
     title: 'Second fake ongoing task',
+    userId: 1,
     tags: [tags.ongoing]
   }
-
-
 
 }

--- a/test/integration/controllers/ActivityController.test.js
+++ b/test/integration/controllers/ActivityController.test.js
@@ -41,7 +41,7 @@ describe('ActivityController', function() {
 
       Task.create({'userId': user.id}).then(function(newTask) {
         task = newTask;
-        Task.update(task.id, {state: 'completed'}).exec(function (err, updated_task) {
+        Task.update(task.id, {id: task.id, state: 'completed'}).exec(function (err, updated_task) {
           user.completedTasks = 1;
 
           Badge.awardForTaskCompletion(task, user, function(err, badges) {

--- a/test/integration/models/Notification-events.test.js
+++ b/test/integration/models/Notification-events.test.js
@@ -1,0 +1,85 @@
+var chai = require('chai');
+var assert = chai.assert;
+var taskFixtures = require('../../fixtures/task');
+var userFixtures = require('../../fixtures/user');
+
+describe('Notification events', function() {
+  var user;
+  beforeEach(function(done) {
+    User.create(userFixtures.minAttrs)
+    .then(function(newUser) {
+      user = newUser;
+      done();
+    }).catch(done);
+  })
+
+  it('should create user.create.welcome', function (done) {
+      Notification.find().limit(1).sort('id DESC')
+      .then(function(notifications) {
+        assert.equal(notifications.length, 1, 'a notification should have been generated');
+        assert.equal(notifications[0].action, 'user.create.welcome');
+        assert.equal(notifications[0].model.username, user.username);
+        done();
+      }).catch(done);
+  });
+  describe('for draft tasks', function() {
+    var task;
+    beforeEach(function(done) {
+      Task.create(taskFixtures.draft)
+      .then(function(newTask) {
+        task = newTask;
+        assert.equal(task.owner, user.id);
+        done();
+      }).catch(done);
+    });
+    it('should create task.create.draft', function (done) {
+        Notification.find().limit(1).sort('id DESC')
+        .then(function(notifications) {
+          assert.equal(notifications.length, 1, 'a notification should have been found');
+          assert.equal(notifications[0].action, 'task.create.draft');
+          assert.equal(notifications[0].model.title, task.title);
+          done();
+        }).catch(done);
+    });
+  });
+  describe('for creating submitted tasks', function() {
+    var task;
+    beforeEach(function(done) {
+      Task.create(taskFixtures.oneTimeSubmitted)
+      .then(function(newTask) {
+        task = newTask;
+        assert.equal(task.owner, user.id);
+        done();
+      }).catch(done);
+    });
+    it('should create task.create.thanks', function (done) {
+        Notification.find().limit(1).sort('id DESC')
+        .then(function(notifications) {
+          assert.equal(notifications.length, 1, 'a notification should have been found');
+          assert.equal(notifications[0].action, 'task.create.thanks');
+          assert.equal(notifications[0].model.title, task.title);
+          done();
+        }).catch(done);
+    });
+    // this is testing a lot of things, but it is really the
+    // important end-user effect and we don't really test
+    // this integration elsewhere
+    it('when published, should create update and badge events', function(done) {
+      Task.update(task.id, {id:task.id, state: 'open'})
+      .then(function(openTask) {
+        return Notification.find().limit(2).sort('id DESC')
+      })
+      .then(function(notifications) {
+        assert.equal(notifications.length, 2, 'notifications should have been found');
+        assert.equal(notifications[0].action, 'badge.create.owner');
+        assert.equal(notifications[0].model.badge.type, 'instigator');
+        assert.equal(notifications[1].action, 'task.update.opened');
+        assert.equal(notifications[1].model.title, task.title);
+        // assert.equal(notifications[1].model.title, task.title);
+        done();
+      }).catch(done);
+    })
+  });
+
+
+})

--- a/test/integration/models/Notification.test.js
+++ b/test/integration/models/Notification.test.js
@@ -1,0 +1,87 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var taskFixtures = require('../../fixtures/task');
+var userFixtures = require('../../fixtures/user');
+
+describe('NotificationModel', function() {
+
+  beforeEach(function(done){
+      done();
+  });
+
+  describe('#create', function() {
+    describe('with data', function() {
+      var notification;
+      var data, action;
+
+      beforeEach(function(done) {
+        data = {name: 'one'};
+        action = 'thing.start';
+        Notification.create({
+          action: action,
+          model: data
+        })
+        .then(function(newNotification) {
+          notification = newNotification;
+          done()
+        })
+        .catch(done);
+      });
+
+      it('should save attributes', function (done) {
+        assert.equal(notification.action, action);
+        assert.deepEqual(notification.model, data);
+        done();
+      });
+    });
+
+    it('should call trigger', function (done) {
+      var oldTrigger = Notification.trigger;
+      var called = false;
+      var notification;
+      Notification.trigger = function(model, cb) {
+        assert.property(model, 'action')
+        assert.equal(model.action, 'whatever')
+        called = true;
+      }
+      Notification.create({action: 'whatever'})
+      .then(function(notification) {
+        assert.equal(called, true);
+        Notification.trigger = oldTrigger;
+        done();
+      })
+      .catch(done);
+    });
+  });
+
+
+  describe('#trigger', function() {
+    var user, task;
+    before(function(done) {
+      User.create(userFixtures.minAttrs)
+      .then(function(newUser) {
+        user = newUser;
+        return Task.create(taskFixtures.draft);
+      })
+      .then(function(newTask) {
+        task = newTask
+        sails.config.emailProtocol = 'SMTP';
+        done();
+      }).catch(done);
+    })
+    after(function() {
+      sails.config.emailProtocol = '';
+    })
+    it('user.create.welcome', function (done) {
+      Notification._transport.sendMail = function mockSend(options, cb) {
+         console.log('==> sendMail', options)
+         cb(null);
+      };
+      Notification.trigger({action: 'user.create.welcome', model:user}, function(err, info) {
+        assert.isNull(err);
+        done();
+      });
+    });
+  });
+
+});

--- a/test/integration/models/Notification.test.js
+++ b/test/integration/models/Notification.test.js
@@ -57,6 +57,19 @@ describe('NotificationModel', function() {
 
   describe('#trigger', function() {
     var user, task;
+
+    function checkTriggerEmail(data, done) {
+      var email;
+      Notification._transport.sendMail = function mockSend(options, cb) {
+        email = options;
+        cb(null);
+      };
+      Notification.trigger(data, function(err, info) {
+        assert.isNull(err);
+        done(err, email);
+      });
+    }
+
     before(function(done) {
       User.create(userFixtures.minAttrs)
       .then(function(newUser) {
@@ -72,15 +85,14 @@ describe('NotificationModel', function() {
     after(function() {
       sails.config.emailProtocol = '';
     })
+
     it('user.create.welcome', function (done) {
-      Notification._transport.sendMail = function mockSend(options, cb) {
-         console.log('==> sendMail', options)
-         cb(null);
-      };
-      Notification.trigger({action: 'user.create.welcome', model:user}, function(err, info) {
-        assert.isNull(err);
+      data = {action: 'user.create.welcome', model:user}
+      checkTriggerEmail(data, function(err, email) {
+        assert.equal(email.to, user.username);
+        assert.equal(email.subject, "Welcome to "+sails.config.systemName);
         done();
-      });
+      })
     });
   });
 

--- a/test/integration/models/Task.test.js
+++ b/test/integration/models/Task.test.js
@@ -52,7 +52,7 @@ describe('TaskModel', function() {
     });
     describe('state', function() {
       it('submitted sets submittedAt', function(done) {
-        Task.update(task.id, {state: 'submitted'}).exec(function (err, updated_task) {
+        Task.update(task.id, {id: task.id, state: 'submitted'}).exec(function (err, updated_task) {
           if ( err ) { return done( err ); }
           assert(updated_task[0].submittedAt <= new Date(), 'submittedAt not set');
           done();
@@ -271,4 +271,5 @@ describe('TaskModel', function() {
       });
     });
   });
+
 });

--- a/tools/demo.js
+++ b/tools/demo.js
@@ -1,7 +1,4 @@
-var async = require("async");
-var fs = require("fs");
 var Promise = require('bluebird');
-
 var Sails = require('sails').constructor;
 var sailsApp = new Sails();
 
@@ -15,10 +12,12 @@ dbTools.checkTableSetup('midas_user')
   return sailsLift({
       log: {
         level: 'error'
-      }
+      },
+      emailProtocol: ''
     });
 })
 .then(function(liftedApp) {
+  // Note that liftedApp === sailsApp
   console.log('config connections:', liftedApp.config.connections);
   console.log('config models.connection:', liftedApp.config.models.connection);
   return sailsModel.importFromFile(sails.models['user'], dataDir + '/users.csv');
@@ -30,7 +29,6 @@ dbTools.checkTableSetup('midas_user')
 .then(function(tasks) {
   console.log('new tasks created: ', tasks);
   console.log("Sails app lifted successfully: http://localhost:"+sailsApp.config.port);
-  // Note that liftedApp === sailsApp
 })
 .catch(function(err) {
   console.log('err: ', err)

--- a/tools/lib/modelTools.js
+++ b/tools/lib/modelTools.js
@@ -1,21 +1,25 @@
 var _ = require('lodash');
 var fs = require('fs');
 var parse = require('csv-parse/lib/sync');
+var Converter = require("csvtojson").Converter;
 
 module.exports = {
   importFromFile: function(model, filepath) {
-    console.log("importing:", filepath);
-    if (fs.existsSync(filepath)) {
-      input = fs.readFileSync(filepath);
-      var attrList = parse(input, {columns: true});
-      var date = new Date();
-      return model.create(attrList);
-    } else {
-      var msg = "File Not Found: '" + filepath + "'"
-      console.log(msg)
-      throw new Error(msg);
+    if (!fs.existsSync(filepath)) {
+      throw new Error("File Not Found: '" + filepath + "'");
     }
+    console.log("importing:", filepath);
+    var converter = new Converter({});
+    return new Promise(function(resolve, reject) {
+      converter.on("end_parsed", function (attrList) {
+        return resolve(model.create(attrList));
+      });
+      converter.on("error", reject);
+      require("fs").createReadStream(filepath).pipe(converter);
+    });
+
   },
+
   importTasksFromFile: function(filepath) {
     console.log("importing:", filepath);
     if (fs.existsSync(filepath)) {

--- a/tools/postgres/importParticipants.js
+++ b/tools/postgres/importParticipants.js
@@ -4,7 +4,7 @@
  * - To run, download a spreadsheet as defined here: https://github.com/18F/midas/issues/1039#issuecomment-148751267
  * - Save spreadsheet as `participants.txt` in the same directory as this script
  * - From this directory, run this script with `node ./importParticipants.js`
- * 
+ *
  * The script will add participants for any rows in the spreadsheet that do not already exist. It will also
  * update tasks with information (like `task_state` or `completion_date`) specified in the spreadsheet.
  *
@@ -123,10 +123,10 @@ function updateTask(row, done) {
   console.log('Updating task ' + row.task_id  + ' to state ' + row.task_state);
 
   // Has to be two steps to avoid automatically setting the date
-  Task.update({ id: +row.task_id }, { state: row.task_state }).exec(function(err) {
+  Task.update({ id: +row.task_id }, { id: +row.task_id, state: row.task_state }).exec(function(err) {
     if (err) return done(err);
     console.log('Updating task ' + row.task_id  + ' to date ' + date);
 
-    Task.update({ id: +row.task_id }, { completedAt: date }).exec(done);
+    Task.update({ id: +row.task_id }, { id: +row.task_id, completedAt: date }).exec(done);
   });
 }


### PR DESCRIPTION
integration tests for many notifications 
basic Notification model tests

The approach is the test the creation of the Notification models on different events
and separately added an option Notification.trigger async callback
which is tested in isolation

also fixed a number of bugs, brought back code for notifications
updateTask needs to supply the id of the task
  in the body, this now throws an error if missing
refactored Task model code, so we’re not calling
  lifecycle callbacks from each other
more logging (verbose)

New high watermark in test coverage:
```
Statements   : 33.99% ( 755/2221 )
Branches     : 22.71% ( 293/1290 )
Functions    : 29.4% ( 157/534 )
Lines        : 36.7% ( 741/2019 )
```