### PR TITLE
version number in footer

### DIFF
--- a/assets/js/backbone/apps/footer/templates/footer_template.html
+++ b/assets/js/backbone/apps/footer/templates/footer_template.html
@@ -1,7 +1,8 @@
 <footer class="container center">
-  <a target="_blank" href="https://github.com/18F/midas"><i class="fa fa-github"></i> Powered by open source</a>
+  <a target="_blank" href="https://github.com/18F/openopps-platform"><i class="fa fa-github"></i> Powered by open source</a>
   |
-  Version <a target="_blank" href="https://github.com/18F/midas/releases/tag/<%- version.version %>"><%- version.version %></a>
+  Version <a target="_blank"
+  href="https://github.com/18F/openopps-platform/releases/tag/v<%- version %>"><%- version %></a>
   <% if (login.terms.enabled === true) { %>
   |
   <a href="<%- login.terms.link %>"><%- login.terms.name %></a>


### PR DESCRIPTION
fixes #1324
also move back to semver #1198
we’ll need to coordinate with version number tags
so from now on tag should start with ‘v’