### PR TITLE
refactor volunteer test a little

### DIFF
--- a/test/integration/models/Volunteer.test.js
+++ b/test/integration/models/Volunteer.test.js
@@ -6,26 +6,28 @@ var Promise = require('bluebird');
 // Reusable utilities
 
 function createUsers(numUsers) {
-  var promises = [];
+  var userAttrs = [];
 
   for (var i = 0; i < numUsers; i++) {
-    promises.push(User.create(
+    userAttrs.push(
       {
         'name': i.toString(),
         'username': i.toString() + '@gmail.com',
         'password': 'TestTest123#'
       }
-    ));
+    );
   }
-
-  return Promise.all(promises);
+  return User.create(userAttrs);
 }
 
-function createVolunteers(users, task) {
+function createVolunteers(users, taskId) {
+  // creating 4 volunteers at once, creates 4 badges, not sure why...
+  // but the app never actually does that
+  // the following code mimicks what the client app would actually do
   var promises = [];
   var resolver = Promise.defer();
   Promise.each(users, function(user, index, length) {
-    var promise = Volunteer.createAction({user: users[index].id, taskId: task});
+    var promise = Volunteer.createAction({user: users[index].id, taskId: taskId});
 
     promises.push(promise);
 
@@ -47,7 +49,6 @@ describe('Volunteer model', function() {
 
       Task.create({userId: ownerUser.id}).then(function(newTask) {
         task = newTask;
-
         done();
       });
     });


### PR DESCRIPTION
more concise code to create all of the users at once
with the volunteers that didn’t create badges correctly
so leaving vol creation one-by-one with note about that

this replaces: https://github.com/18F/openopps-platform/pull/1312
re-applied to dev branch and removed commented out code