### PR TITLE
Home page call-to-action shouldn’t require login

### DIFF
--- a/assets/js/backbone/apps/home/templates/home_view_template.html
+++ b/assets/js/backbone/apps/home/templates/home_view_template.html
@@ -5,7 +5,7 @@
     <hr/>
     <p class="tagline text-center" data-i18n="home.tagline">Building a 21st century government, together</p>
     <div class="text-center">
-      <a class="login" href="/tasks">
+      <a href="/tasks">
         <button class="btn btn-midas" id="center" data-i18n="home.callToAction">Get Started Today</button>
       </a>
     </div>
@@ -51,7 +51,7 @@
 <div class="container-fluid px0 final-call">
   <div class="text-center col-md-8 col-md-offset-2">
     <p class="title">Find Open Opportunities that match your skills or let you explore new horizons while making an impact across government.</p>
-    <a class="login" href="/tasks">
+    <a href="/tasks">
       <button class="btn btn-midas" id="center">Discover More</button>
     </a>
   </div>


### PR DESCRIPTION
We talked about this a while back, 
but didn’t get around to fixing till now
We want to engage people as much as possible
and only require registration / login when needed 
for task creation and sign up

fixes: #1325