### PR TITLE
added links to task edit form template

### DIFF
--- a/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
+++ b/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
@@ -195,8 +195,8 @@
     </div>
     <aside>
       <h4>Guidance for Creating Tasks</h4>
-      <p>If you're new to posting opportunities, <a>10 Tips for Creating the Perfect Open Opportunity Task</a> will get you headed in the right direction.</p>
-      <p>Information on the task creation process is in the <a>Task Creator Toolkit</a>.</p>
+      <p>If you're new to posting opportunities, <a href="http://www.digitalgov.gov/resources/open-opportunities-task-creator-toolkit/10-tips-for-creating-the-perfect-open-opportunity-task/" target="_blank">10 Tips for Creating the Perfect Open Opportunity Task</a> will get you headed in the right direction.</p>
+      <p>Information on the task creation process is in the <a href="http://www.digitalgov.gov/resources/open-opportunities-task-creator-toolkit/" target="_blank">Task Creator Toolkit</a>.</p>
     </aside>
   </div>
 </div>


### PR DESCRIPTION
This pull request addresses #1240. I copied the links from [task_form_template.html](https://github.com/18F/openopps-platform/blob/38a2570828aae818e7cdc8e6041b506e0a99eaa3/assets/js/backbone/apps/tasks/new/templates/task_form_template.html). They match [those cited by LisaLNelson](https://github.com/18F/openopps-platform/issues/1240#issuecomment-182423229).