### PR TITLE
fix bug with undefined volunteer name

### DIFF
--- a/assets/js/backbone/apps/admin/templates/admin_task_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_task_template.html
@@ -74,7 +74,7 @@
                         <% if ( task.volunteers.length ) { %>
                         <p><i>Sign-ups</i>
                           <% _( task.volunteers ).forEach( function( vol ) { %>
-                            <a href="/profile/<%- vol.userId %>"><%- vol.name || vol.user.username %></a>
+                            <a href="/profile/<%- vol.userId %>"><%-vol.name || 'Unnamed'%></a><%-(vol == task.volunteers[task.volunteers.length-1]) ? '' : ', ' %>
                           <% } ); %>
                         </p>
                         <% } %>
@@ -135,7 +135,7 @@
                         <% if ( task.volunteers.length ) { %>
                         <p><i>Sign-ups</i>
                           <% _( task.volunteers ).forEach( function( vol ) { %>
-                            <a href="/profile/<%- vol.userId %>"><%- vol.name || vol.user.username %></a>
+                            <a href="/profile/<%- vol.userId %>"><%-vol.name || 'Unnamed'%></a><%-(vol == task.volunteers[task.volunteers.length-1]) ? '' : ', ' %>
                           <% } ); %>
                         </p>
                         <% } %>
@@ -175,7 +175,7 @@
                         <% if ( task.volunteers.length ) { %>
                         <p><i>Sign-ups</i>
                           <% _( task.volunteers ).forEach( function( vol ) { %>
-                            <a href="/profile/<%- vol.userId %>"><%- vol.name || vol.user.username %></a>
+                            <a href="/profile/<%- vol.userId %>"><%-vol.name || 'Unnamed'%></a><%-(vol == task.volunteers[task.volunteers.length-1]) ? '' : ', ' %>
                           <% } ); %>
                         </p>
                         <% } %>
@@ -212,13 +212,6 @@
                       </td>
                       <td class="metrics-table__title">
                         <a href="/tasks/<%- task.id %>"><%- task.title %></a>
-                        <% if ( task.volunteers.length ) { %>
-                        <p><i>Sign-ups</i>
-                          <% _( task.volunteers ).forEach( function( vol ) { %>
-                            <a href="/profile/<%- vol.userId %>"><%- vol.name || vol.user.username %></a>
-                          <% } ); %>
-                        </p>
-                        <% } %>
                       </td>
                       <td class="metrics-table__author">
                         <a href="/profile/<%- task.owner.id %>">


### PR DESCRIPTION
in admin/tasks
in 0.9.5, I think there were never volunteers in completed
since server API is now more consistent, bug appeared
fixed in UI in two ways
- don’t display signups for completed tasks (more efficient)
- if vol has no name, display as “Unnamed”
also added comma between names to make it more readable

FYI: this only showed up with production data, didn't appear on openopps-test